### PR TITLE
De-emphasize "Part N" subtitle in long titles (+ re-land series nav)

### DIFF
--- a/app/blog/BlogIndexClient.tsx
+++ b/app/blog/BlogIndexClient.tsx
@@ -5,6 +5,7 @@ import Link from 'next/link'
 import { Calendar, Clock, ArrowLeft, Search, Tag } from 'lucide-react'
 import type { BlogPostMeta } from '@/lib/blog'
 import ThemeToggle from '@/components/ThemeToggle'
+import { PostTitle } from '@/components/PostTitle'
 
 interface BlogIndexClientProps {
   posts: BlogPostMeta[]
@@ -119,8 +120,10 @@ export default function BlogIndexClient({ posts }: BlogIndexClientProps) {
                   </div>
                 </div>
 
-                <h2 className="mb-3 text-2xl font-bold text-fg transition-colors hover:text-accent">
-                  <Link href={`/blog/${post.slug}`}>{post.title}</Link>
+                <h2 className="mb-3 text-balance text-2xl font-bold text-fg transition-colors hover:text-accent">
+                  <Link href={`/blog/${post.slug}`}>
+                    <PostTitle title={post.title} variant="inline" />
+                  </Link>
                 </h2>
 
                 <p className="mb-4 leading-relaxed text-muted">{post.excerpt}</p>

--- a/app/blog/[slug]/BlogPostClient.tsx
+++ b/app/blog/[slug]/BlogPostClient.tsx
@@ -2,15 +2,23 @@
 
 import Link from 'next/link'
 import { Calendar, Clock, ArrowLeft, Tag, Share2 } from 'lucide-react'
-import type { BlogPost, BlogPostMeta } from '@/lib/blog'
+import type { BlogPost, BlogPostMeta, SeriesPart } from '@/lib/blog'
 import ThemeToggle from '@/components/ThemeToggle'
+import { SeriesNav, SeriesPager } from '@/components/SeriesNav'
 
 interface BlogPostClientProps {
   post: BlogPost
   allPosts: BlogPostMeta[]
+  seriesTitle: string | null
+  seriesParts: SeriesPart[]
 }
 
-export default function BlogPostClient({ post, allPosts }: BlogPostClientProps) {
+export default function BlogPostClient({
+  post,
+  allPosts,
+  seriesTitle,
+  seriesParts,
+}: BlogPostClientProps) {
   const handleShare = async () => {
     if (navigator.share) {
       try {
@@ -87,12 +95,16 @@ export default function BlogPostClient({ post, allPosts }: BlogPostClientProps) 
 
       <div className="container-max section-padding py-12">
         <div className="mx-auto max-w-4xl">
+          {seriesTitle && <SeriesNav title={seriesTitle} parts={seriesParts} />}
+
           <article>
             <div
               className="prose prose-lg max-w-none dark:prose-invert prose-a:text-accent hover:prose-a:opacity-80"
               dangerouslySetInnerHTML={{ __html: post.contentHtml }}
             />
           </article>
+
+          <SeriesPager parts={seriesParts} />
 
           {related.length > 0 && (
             <div className="mt-16 border-t border-line pt-12">

--- a/app/blog/[slug]/BlogPostClient.tsx
+++ b/app/blog/[slug]/BlogPostClient.tsx
@@ -5,6 +5,7 @@ import { Calendar, Clock, ArrowLeft, Tag, Share2 } from 'lucide-react'
 import type { BlogPost, BlogPostMeta, SeriesPart } from '@/lib/blog'
 import ThemeToggle from '@/components/ThemeToggle'
 import { SeriesNav, SeriesPager } from '@/components/SeriesNav'
+import { PostTitle } from '@/components/PostTitle'
 
 interface BlogPostClientProps {
   post: BlogPost
@@ -64,8 +65,8 @@ export default function BlogPostClient({
               ))}
             </div>
 
-            <h1 className="mb-4 text-4xl font-bold leading-tight tracking-tight text-fg md:text-5xl">
-              {post.title}
+            <h1 className="mb-4 max-w-3xl text-balance text-3xl font-bold leading-[1.1] tracking-tight text-fg sm:text-4xl md:text-5xl">
+              <PostTitle title={post.title} variant="full" />
             </h1>
 
             <div className="flex flex-col md:flex-row md:items-center md:justify-between">
@@ -116,8 +117,8 @@ export default function BlogPostClient({
                     href={`/blog/${rp.slug}`}
                     className="group block py-6 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
                   >
-                    <h4 className="mb-2 text-lg font-semibold text-fg transition-colors group-hover:text-accent">
-                      {rp.title}
+                    <h4 className="mb-2 text-balance text-lg font-semibold leading-snug text-fg transition-colors group-hover:text-accent">
+                      <PostTitle title={rp.title} variant="inline" />
                     </h4>
                     <p className="mb-3 text-sm text-muted">{rp.excerpt}</p>
                     <div className="flex items-center text-sm text-faint">

--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -1,5 +1,5 @@
 import { notFound } from 'next/navigation'
-import { getAllSlugs, getAllPostsMeta, getPostBySlug } from '@/lib/blog'
+import { getAllSlugs, getAllPostsMeta, getPostBySlug, getSeriesParts } from '@/lib/blog'
 import BlogPostClient from './BlogPostClient'
 
 interface BlogPostPageProps {
@@ -14,5 +14,13 @@ export default async function BlogPostPage({ params }: BlogPostPageProps) {
   const post = await getPostBySlug(params.slug)
   if (!post) notFound()
   const allPosts = getAllPostsMeta()
-  return <BlogPostClient post={post} allPosts={allPosts} />
+  const seriesParts = post.series ? getSeriesParts(post.series.title, post.slug) : []
+  return (
+    <BlogPostClient
+      post={post}
+      allPosts={allPosts}
+      seriesTitle={post.series?.title ?? null}
+      seriesParts={seriesParts}
+    />
+  )
 }

--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -14,7 +14,7 @@ export default async function BlogPostPage({ params }: BlogPostPageProps) {
   const post = await getPostBySlug(params.slug)
   if (!post) notFound()
   const allPosts = getAllPostsMeta()
-  const seriesParts = post.series ? getSeriesParts(post.series.title, post.slug) : []
+  const seriesParts = post.series ? getSeriesParts(post.series.id, post.slug) : []
   return (
     <BlogPostClient
       post={post}

--- a/components/PostTitle.tsx
+++ b/components/PostTitle.tsx
@@ -1,0 +1,62 @@
+import { splitTitle } from '@/lib/title'
+
+/**
+ * Renders a post title with the "— Part N: …" tail visually de-emphasized,
+ * while keeping the full title as a single string inside one heading element
+ * (the caller supplies the <h1>/<h2>/<h3> and any <Link>). Screen readers and
+ * SEO still see the complete title.
+ *
+ * - variant="full"   stacked 3-tier hierarchy for the post-page H1.
+ * - variant="inline" main + dimmed inline tail for compact listing/related cards.
+ */
+export function PostTitle({
+  title,
+  variant,
+  className,
+}: {
+  title: string
+  variant: 'full' | 'inline'
+  className?: string
+}) {
+  const { main, part, subtitle } = splitTitle(title)
+  const hasTail = Boolean(part || subtitle)
+
+  if (variant === 'inline') {
+    return (
+      <span className={className}>
+        {main}
+        {hasTail && (
+          <span className="font-normal text-muted">
+            {' — '}
+            {part ? `${part}: ` : ''}
+            {subtitle}
+          </span>
+        )}
+      </span>
+    )
+  }
+
+  return (
+    <span className={className}>
+      <span className="block text-balance">{main}</span>
+      {hasTail && (
+        <span className="mt-3 block">
+          {/* sr-only separators keep the heading's text content equal to the
+              original title for screen readers and SEO, despite the visual split. */}
+          <span className="sr-only">{' — '}</span>
+          {part && (
+            <span className="block font-mono text-xs uppercase tracking-[0.2em] text-accent">
+              {part}
+              {subtitle && <span className="sr-only">: </span>}
+            </span>
+          )}
+          {subtitle && (
+            <span className="mt-1.5 block text-pretty text-lg font-normal leading-snug text-muted sm:text-xl">
+              {subtitle}
+            </span>
+          )}
+        </span>
+      )}
+    </span>
+  )
+}

--- a/components/SeriesNav.tsx
+++ b/components/SeriesNav.tsx
@@ -1,0 +1,122 @@
+import Link from 'next/link'
+import { Layers, ArrowLeft, ArrowRight } from 'lucide-react'
+import type { SeriesPart } from '@/lib/blog'
+
+function PartNumber({ part, active }: { part: number; active: boolean }) {
+  return (
+    <span
+      aria-hidden
+      className={`flex h-6 w-6 shrink-0 items-center justify-center rounded-md font-mono text-xs ${
+        active ? 'bg-accent text-bg' : 'border border-line text-faint'
+      }`}
+    >
+      {part}
+    </span>
+  )
+}
+
+/**
+ * Top-of-article series card: lists every part with the current one
+ * highlighted. Rendered only for posts that belong to a series.
+ */
+export function SeriesNav({ title, parts }: { title: string; parts: SeriesPart[] }) {
+  if (parts.length < 2) return null
+  const current = parts.find((p) => p.isCurrent)
+
+  return (
+    <nav aria-label="Article series" className="panel mb-10 overflow-hidden">
+      <div className="flex items-center gap-2 border-b border-line px-5 py-3">
+        <Layers size={14} className="text-accent" />
+        <span className="eyebrow">Series</span>
+        {current && (
+          <span className="ml-auto font-mono text-xs text-faint">
+            Part {current.part} of {parts.length}
+          </span>
+        )}
+      </div>
+
+      <div className="px-3 py-3 sm:px-4">
+        <p className="px-2 pb-2 text-sm font-semibold tracking-tight text-fg">{title}</p>
+        <ol className="space-y-0.5">
+          {parts.map((p) =>
+            p.isCurrent ? (
+              <li key={p.slug}>
+                <span
+                  aria-current="page"
+                  className="flex items-center gap-3 rounded-md bg-accent/10 px-2 py-2 text-sm text-fg"
+                >
+                  <PartNumber part={p.part} active />
+                  <span className="font-medium">{p.label}</span>
+                  <span className="eyebrow ml-auto text-accent">You are here</span>
+                </span>
+              </li>
+            ) : (
+              <li key={p.slug}>
+                <Link
+                  href={`/blog/${p.slug}`}
+                  className="group flex items-center gap-3 rounded-md px-2 py-2 text-sm text-muted transition-colors hover:bg-accent/5 hover:text-fg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+                >
+                  <PartNumber part={p.part} active={false} />
+                  <span className="transition-colors group-hover:text-fg">{p.label}</span>
+                </Link>
+              </li>
+            ),
+          )}
+        </ol>
+      </div>
+    </nav>
+  )
+}
+
+/**
+ * Bottom-of-article previous/next pager within a series.
+ */
+export function SeriesPager({ parts }: { parts: SeriesPart[] }) {
+  if (parts.length < 2) return null
+  const idx = parts.findIndex((p) => p.isCurrent)
+  if (idx === -1) return null
+  const prev = parts[idx - 1]
+  const next = parts[idx + 1]
+  if (!prev && !next) return null
+
+  return (
+    <nav
+      aria-label="Series navigation"
+      className="mt-16 grid gap-4 border-t border-line pt-8 sm:grid-cols-2"
+    >
+      {prev ? (
+        <Link
+          href={`/blog/${prev.slug}`}
+          className="panel group p-4 transition-colors hover:border-line-strong focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+        >
+          <span className="eyebrow flex items-center gap-1">
+            <ArrowLeft size={12} />
+            Previous · Part {prev.part}
+          </span>
+          <span className="mt-1.5 block text-sm font-medium text-fg transition-colors group-hover:text-accent">
+            {prev.label}
+          </span>
+        </Link>
+      ) : (
+        <span className="hidden sm:block" />
+      )}
+
+      {next ? (
+        <Link
+          href={`/blog/${next.slug}`}
+          className="panel group p-4 text-right transition-colors hover:border-line-strong focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+        >
+          <span className="eyebrow flex items-center justify-end gap-1">
+            Next · Part {next.part}
+            <ArrowRight size={12} />
+          </span>
+          <span className="mt-1.5 block text-sm font-medium text-fg transition-colors group-hover:text-accent">
+            {next.label}
+          </span>
+        </Link>
+      ) : (
+        <span className="hidden sm:block" />
+      )}
+    </nav>
+  )
+}

--- a/components/SeriesNav.tsx
+++ b/components/SeriesNav.tsx
@@ -46,7 +46,10 @@ export function SeriesNav({ title, parts }: { title: string; parts: SeriesPart[]
                   className="flex items-center gap-3 rounded-md bg-accent/10 px-2 py-2 text-sm text-fg"
                 >
                   <PartNumber part={p.part} active />
-                  <span className="font-medium">{p.label}</span>
+                  <span className="font-medium">
+                    <span className="sr-only">Part {p.part}: </span>
+                    {p.label}
+                  </span>
                   <span className="eyebrow ml-auto text-accent">You are here</span>
                 </span>
               </li>
@@ -57,7 +60,10 @@ export function SeriesNav({ title, parts }: { title: string; parts: SeriesPart[]
                   className="group flex items-center gap-3 rounded-md px-2 py-2 text-sm text-muted transition-colors hover:bg-accent/5 hover:text-fg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
                 >
                   <PartNumber part={p.part} active={false} />
-                  <span className="transition-colors group-hover:text-fg">{p.label}</span>
+                  <span className="transition-colors group-hover:text-fg">
+                    <span className="sr-only">Part {p.part}: </span>
+                    {p.label}
+                  </span>
                 </Link>
               </li>
             ),
@@ -69,7 +75,8 @@ export function SeriesNav({ title, parts }: { title: string; parts: SeriesPart[]
 }
 
 /**
- * Bottom-of-article previous/next pager within a series.
+ * Bottom-of-article previous/next pager within a series. A lone card (first
+ * or last part) spans the full row instead of floating in one column.
  */
 export function SeriesPager({ parts }: { parts: SeriesPart[] }) {
   if (parts.length < 2) return null
@@ -82,9 +89,11 @@ export function SeriesPager({ parts }: { parts: SeriesPart[] }) {
   return (
     <nav
       aria-label="Series navigation"
-      className="mt-16 grid gap-4 border-t border-line pt-8 sm:grid-cols-2"
+      className={`mt-16 grid gap-4 border-t border-line pt-8 ${
+        prev && next ? 'sm:grid-cols-2' : 'sm:grid-cols-1'
+      }`}
     >
-      {prev ? (
+      {prev && (
         <Link
           href={`/blog/${prev.slug}`}
           className="panel group p-4 transition-colors hover:border-line-strong focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
@@ -97,16 +106,14 @@ export function SeriesPager({ parts }: { parts: SeriesPart[] }) {
             {prev.label}
           </span>
         </Link>
-      ) : (
-        <span className="hidden sm:block" />
       )}
 
-      {next ? (
+      {next && (
         <Link
           href={`/blog/${next.slug}`}
-          className="panel group p-4 text-right transition-colors hover:border-line-strong focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+          className="panel group p-4 transition-colors hover:border-line-strong focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent sm:text-right"
         >
-          <span className="eyebrow flex items-center justify-end gap-1">
+          <span className="eyebrow flex items-center gap-1 sm:justify-end">
             Next · Part {next.part}
             <ArrowRight size={12} />
           </span>
@@ -114,8 +121,6 @@ export function SeriesPager({ parts }: { parts: SeriesPart[] }) {
             {next.label}
           </span>
         </Link>
-      ) : (
-        <span className="hidden sm:block" />
       )}
     </nav>
   )

--- a/content/posts/cross-checking-post-quantum-kem-part-2.md
+++ b/content/posts/cross-checking-post-quantum-kem-part-2.md
@@ -3,6 +3,7 @@ title: "Cross-checking the post-quantum KEM behind the web — Part 2: the Borin
 date: 2026-04-25
 excerpt: "Part 2 of 3. G1, a §7.3 hash-check gap in BoringSSL found by reading rather than fuzzing; the assurance-coverage share across the encrypted web; who each finding affects; and the Compress/Decompress clean sweep."
 tags: ["post-quantum", "ml-kem", "fips-203", "differential-fuzzing", "cryptography"]
+seriesId: mlkem-cross-check
 series: "Cross-checking the post-quantum KEM behind the web"
 seriesPart: 2
 seriesLabel: "The BoringSSL §7.3 finding & coverage"

--- a/content/posts/cross-checking-post-quantum-kem-part-2.md
+++ b/content/posts/cross-checking-post-quantum-kem-part-2.md
@@ -3,9 +3,10 @@ title: "Cross-checking the post-quantum KEM behind the web — Part 2: the Borin
 date: 2026-04-25
 excerpt: "Part 2 of 3. G1, a §7.3 hash-check gap in BoringSSL found by reading rather than fuzzing; the assurance-coverage share across the encrypted web; who each finding affects; and the Compress/Decompress clean sweep."
 tags: ["post-quantum", "ml-kem", "fips-203", "differential-fuzzing", "cryptography"]
+series: "Cross-checking the post-quantum KEM behind the web"
+seriesPart: 2
+seriesLabel: "The BoringSSL §7.3 finding & coverage"
 ---
-
-[Part 1](/blog/cross-checking-post-quantum-kem) \| **Part 2** \| [Part 3](/blog/cross-checking-post-quantum-kem-part-3)
 
 > **TL;DR (Part 2 of 3).** The second filing, **G1**, came from *reading* code
 > rather than fuzzing: BoringSSL's BCM-boundary `mlkem_parse_private_key`

--- a/content/posts/cross-checking-post-quantum-kem-part-3.md
+++ b/content/posts/cross-checking-post-quantum-kem-part-3.md
@@ -3,9 +3,10 @@ title: "Cross-checking the post-quantum KEM behind the web — Part 3: blind spo
 date: 2026-04-26
 excerpt: "Part 3 of 3. What a clean multi-way negative does and doesn't prove — the methodology's blind spots — plus the takeaway and how to reproduce the work."
 tags: ["post-quantum", "ml-kem", "fips-203", "differential-fuzzing", "cryptography"]
+series: "Cross-checking the post-quantum KEM behind the web"
+seriesPart: 3
+seriesLabel: "Blind spots & what's next"
 ---
-
-[Part 1](/blog/cross-checking-post-quantum-kem) \| [Part 2](/blog/cross-checking-post-quantum-kem-part-2) \| **Part 3**
 
 > **TL;DR (Part 3 of 3).** A clean multi-way negative is narrower than it
 > sounds. This part names the methodology's blind spots — shared-correctness

--- a/content/posts/cross-checking-post-quantum-kem-part-3.md
+++ b/content/posts/cross-checking-post-quantum-kem-part-3.md
@@ -3,6 +3,7 @@ title: "Cross-checking the post-quantum KEM behind the web — Part 3: blind spo
 date: 2026-04-26
 excerpt: "Part 3 of 3. What a clean multi-way negative does and doesn't prove — the methodology's blind spots — plus the takeaway and how to reproduce the work."
 tags: ["post-quantum", "ml-kem", "fips-203", "differential-fuzzing", "cryptography"]
+seriesId: mlkem-cross-check
 series: "Cross-checking the post-quantum KEM behind the web"
 seriesPart: 3
 seriesLabel: "Blind spots & what's next"

--- a/content/posts/cross-checking-post-quantum-kem.md
+++ b/content/posts/cross-checking-post-quantum-kem.md
@@ -3,9 +3,10 @@ title: "Cross-checking the post-quantum KEM behind the web — Part 1: the setup
 date: 2026-04-24
 excerpt: "Part 1 of 3. One in twelve web connections rides X25519MLKEM768. I wired the five ML-KEM libraries behind it into one diff-fuzz harness — and it caught F1, a FIPS 203 §7.2 modulus-check bypass in CIRCL's expanded-SK parser."
 tags: ["post-quantum", "ml-kem", "fips-203", "differential-fuzzing", "cryptography"]
+series: "Cross-checking the post-quantum KEM behind the web"
+seriesPart: 1
+seriesLabel: "Setup & the CIRCL §7.2 finding"
 ---
-
-**Part 1** \| [Part 2](/blog/cross-checking-post-quantum-kem-part-2) \| [Part 3](/blog/cross-checking-post-quantum-kem-part-3)
 
 > **TL;DR (Part 1 of 3).** Roughly one in twelve human web connections rides
 > `X25519MLKEM768`. I wired the five ML-KEM libraries behind it into one

--- a/content/posts/cross-checking-post-quantum-kem.md
+++ b/content/posts/cross-checking-post-quantum-kem.md
@@ -3,6 +3,7 @@ title: "Cross-checking the post-quantum KEM behind the web — Part 1: the setup
 date: 2026-04-24
 excerpt: "Part 1 of 3. One in twelve web connections rides X25519MLKEM768. I wired the five ML-KEM libraries behind it into one diff-fuzz harness — and it caught F1, a FIPS 203 §7.2 modulus-check bypass in CIRCL's expanded-SK parser."
 tags: ["post-quantum", "ml-kem", "fips-203", "differential-fuzzing", "cryptography"]
+seriesId: mlkem-cross-check
 series: "Cross-checking the post-quantum KEM behind the web"
 seriesPart: 1
 seriesLabel: "Setup & the CIRCL §7.2 finding"

--- a/content/posts/diagnosing-distributed-vulnerabilities.md
+++ b/content/posts/diagnosing-distributed-vulnerabilities.md
@@ -3,9 +3,10 @@ title: "Diagnosing Distributed Vulnerabilities"
 date: 2017-08-02
 excerpt: "Methods and techniques for identifying and analyzing security vulnerabilities in distributed systems and network protocols."
 tags: ["security", "distributed-systems", "vulnerabilities", "analysis"]
+series: "Compiler-assisted vulnerability diagnosis"
+seriesPart: 1
+seriesLabel: "Diagnosing distributed vulnerabilities"
 ---
-
-[Part 1][1] \| [Part 2][2] \| [Part 3][3]
 
 ## Prologue
 
@@ -180,11 +181,6 @@ main() -> vulnerable()
 
 I have had modest success with the proposed approach. The proposal definitely provides more context for identifying vulnerabilities in source code. Specifically, enlisting LLVM passes to tell me more about a local bug has helped navigate code and identify false positives early. Moreover, the prototype scales up nicely to large codebases such as Chromium, and Firefox. For example, I could perform end-to-end analysis of these and MySQL codebases in under 48h (roughly 100 Euros renting a 32 vCPU EC2 instance). Having said that, the [vulnerabilities identified by the present incarnation of the tool][8] are limited to known issues in the evaluated projects. A more extensive evaluation of the tool across a larger number of open-source projects will help understand its utility towards early vulnerability diagnosis.
 
-[Part 1][1] \| [Part 2][2] \| [Part 3][3]
-
-[1]: {{ site.baseurl }}{% post_url 2017-08-02-Diagnosing-Distributed-Vulnerabilities %}
-[2]: {{ site.baseurl }}{% post_url 2017-08-03-Inferring-Program-Input-Format %}
-[3]: {{ site.baseurl }}{% post_url 2017-08-04-Exploring-Fuzzer-Crashes %}
 [4]: https://link.springer.com/chapter/10.1007/978-3-319-40667-1_5
 [5]: https://www.github.com/bshastry/melange-checkers
 [6]: https://github.com/bshastry/vagrant-pallang

--- a/content/posts/diagnosing-distributed-vulnerabilities.md
+++ b/content/posts/diagnosing-distributed-vulnerabilities.md
@@ -3,6 +3,7 @@ title: "Diagnosing Distributed Vulnerabilities"
 date: 2017-08-02
 excerpt: "Methods and techniques for identifying and analyzing security vulnerabilities in distributed systems and network protocols."
 tags: ["security", "distributed-systems", "vulnerabilities", "analysis"]
+seriesId: compiler-assisted-vuln-diagnosis
 series: "Compiler-assisted vulnerability diagnosis"
 seriesPart: 1
 seriesLabel: "Diagnosing distributed vulnerabilities"

--- a/content/posts/exploring-fuzzer-crashes.md
+++ b/content/posts/exploring-fuzzer-crashes.md
@@ -3,6 +3,7 @@ title: "Exploring Fuzzer Crashes"
 date: 2017-08-04
 excerpt: "Deep dive into analyzing and understanding crashes discovered through fuzzing, including crash triage and root cause analysis."
 tags: ["fuzzing", "crash-analysis", "debugging", "security"]
+seriesId: compiler-assisted-vuln-diagnosis
 series: "Compiler-assisted vulnerability diagnosis"
 seriesPart: 3
 seriesLabel: "Exploring fuzzer crashes"

--- a/content/posts/exploring-fuzzer-crashes.md
+++ b/content/posts/exploring-fuzzer-crashes.md
@@ -3,9 +3,10 @@ title: "Exploring Fuzzer Crashes"
 date: 2017-08-04
 excerpt: "Deep dive into analyzing and understanding crashes discovered through fuzzing, including crash triage and root cause analysis."
 tags: ["fuzzing", "crash-analysis", "debugging", "security"]
+series: "Compiler-assisted vulnerability diagnosis"
+seriesPart: 3
+seriesLabel: "Exploring fuzzer crashes"
 ---
-
-[Part 1][1] \| [Part 2][2] \| [Part 3][3]
 
 ## Prologue
 
@@ -313,11 +314,6 @@ Prominently, we showed that our method could spot a security issue that was a re
 The analysis undertaken is fast and thus doable on a regular basis e.g., CI.
 I think the approach taken in this work holds promise for catching other classes of recurring vulns in large codebases.
 
-[Part 1][1] \| [Part 2][2] \| [Part 3][3]
-
-[1]: {{ site.baseurl }}{% post_url 2017-08-02-Diagnosing-Distributed-Vulnerabilities %}
-[2]: {{ site.baseurl }}{% post_url 2017-08-03-Inferring-Program-Input-Format %}
-[3]: {{ site.baseurl }}{% post_url 2017-08-04-Exploring-Fuzzer-Crashes %}
 [4]: https://dl.acm.org/citation.cfm?id=2519842
 [5]: https://github.com/jfoote/exploitable
 [6]: http://releases.llvm.org/3.8.1/tools/docs/SanitizerCoverage.html

--- a/content/posts/inferring-program-input-format.md
+++ b/content/posts/inferring-program-input-format.md
@@ -3,6 +3,7 @@ title: "Inferring Program Input Format"
 date: 2017-08-03
 excerpt: "Techniques for automatically inferring and understanding the input format requirements of programs for more effective testing."
 tags: ["program-analysis", "input-format", "reverse-engineering", "testing"]
+seriesId: compiler-assisted-vuln-diagnosis
 series: "Compiler-assisted vulnerability diagnosis"
 seriesPart: 2
 seriesLabel: "Inferring program input format"

--- a/content/posts/inferring-program-input-format.md
+++ b/content/posts/inferring-program-input-format.md
@@ -3,9 +3,10 @@ title: "Inferring Program Input Format"
 date: 2017-08-03
 excerpt: "Techniques for automatically inferring and understanding the input format requirements of programs for more effective testing."
 tags: ["program-analysis", "input-format", "reverse-engineering", "testing"]
+series: "Compiler-assisted vulnerability diagnosis"
+seriesPart: 2
+seriesLabel: "Inferring program input format"
 ---
-
-[Part 1][1] \| [Part 2][2] \| [Part 3][3]
 
 ## Prologue
 
@@ -204,10 +205,5 @@ However, dictionaries can support them by triggering these code paths much faste
 You can read the [full paper][5] (to be published in the proceedings of RAID'17 by Springer) that this work produced and form your own opinion.
 
 
-[Part 1][1] \| [Part 2][2] \| [Part 3][3]
-
-[1]: {{ site.baseurl }}{% post_url 2017-08-02-Diagnosing-Distributed-Vulnerabilities %}
-[2]: {{ site.baseurl }}{% post_url 2017-08-03-Inferring-Program-Input-Format %}
-[3]: {{ site.baseurl }}{% post_url 2017-08-04-Exploring-Fuzzer-Crashes %}
 [4]: https://llvm.org/docs/LibFuzzer.html
 [5]: http://users.sec.t-labs.tu-berlin.de/~bshastry/raid17.pdf

--- a/lib/blog.ts
+++ b/lib/blog.ts
@@ -12,6 +12,22 @@ import rehypeStringify from 'rehype-stringify'
 
 const POSTS_DIR = path.join(process.cwd(), 'content/posts')
 
+export interface SeriesInfo {
+  /** Display title of the series; also the grouping key across posts. */
+  title: string
+  /** 1-based position of this post within the series. */
+  part: number
+  /** Short label for this part in the nav; falls back to the post title. */
+  label?: string
+}
+
+export interface SeriesPart {
+  slug: string
+  part: number
+  label: string
+  isCurrent: boolean
+}
+
 export interface BlogPostMeta {
   slug: string
   title: string
@@ -19,6 +35,7 @@ export interface BlogPostMeta {
   excerpt: string
   tags: string[]
   readTime: string
+  series?: SeriesInfo
 }
 
 export interface BlogPost extends BlogPostMeta {
@@ -30,6 +47,18 @@ interface PostFrontmatter {
   date: string | Date
   excerpt: string
   tags: string[]
+  series?: string
+  seriesPart?: number
+  seriesLabel?: string
+}
+
+function parseSeries(frontmatter: PostFrontmatter): SeriesInfo | undefined {
+  if (!frontmatter.series || frontmatter.seriesPart == null) return undefined
+  return {
+    title: frontmatter.series,
+    part: frontmatter.seriesPart,
+    label: frontmatter.seriesLabel,
+  }
 }
 
 function normalizeDate(date: string | Date): string {
@@ -63,7 +92,7 @@ export function getAllSlugs(): string[] {
 
 export function getAllPostsMeta(): BlogPostMeta[] {
   return getAllSlugs()
-    .map((slug) => {
+    .map((slug): BlogPostMeta | null => {
       const parsed = readPostFile(slug)
       if (!parsed) return null
       const { frontmatter, body } = parsed
@@ -74,10 +103,28 @@ export function getAllPostsMeta(): BlogPostMeta[] {
         excerpt: frontmatter.excerpt,
         tags: frontmatter.tags ?? [],
         readTime: computeReadTime(body),
+        series: parseSeries(frontmatter),
       }
     })
     .filter((p): p is BlogPostMeta => p !== null)
     .sort((a, b) => (a.date < b.date ? 1 : -1))
+}
+
+/**
+ * All posts in a series, ordered by part. Returns [] when the series has
+ * fewer than two posts (a lone post is not a series).
+ */
+export function getSeriesParts(seriesTitle: string, currentSlug?: string): SeriesPart[] {
+  const parts = getAllPostsMeta()
+    .filter((p) => p.series?.title === seriesTitle)
+    .sort((a, b) => a.series!.part - b.series!.part)
+    .map((p) => ({
+      slug: p.slug,
+      part: p.series!.part,
+      label: p.series!.label ?? p.title,
+      isCurrent: p.slug === currentSlug,
+    }))
+  return parts.length > 1 ? parts : []
 }
 
 export async function getPostBySlug(slug: string): Promise<BlogPost | null> {
@@ -105,6 +152,7 @@ export async function getPostBySlug(slug: string): Promise<BlogPost | null> {
     excerpt: frontmatter.excerpt,
     tags: frontmatter.tags ?? [],
     readTime: computeReadTime(body),
+    series: parseSeries(frontmatter),
     contentHtml: String(processed),
   }
 }

--- a/lib/blog.ts
+++ b/lib/blog.ts
@@ -13,7 +13,9 @@ import rehypeStringify from 'rehype-stringify'
 const POSTS_DIR = path.join(process.cwd(), 'content/posts')
 
 export interface SeriesInfo {
-  /** Display title of the series; also the grouping key across posts. */
+  /** Stable grouping key shared by every post in the series. */
+  id: string
+  /** Display title of the series. */
   title: string
   /** 1-based position of this post within the series. */
   part: number
@@ -47,18 +49,23 @@ interface PostFrontmatter {
   date: string | Date
   excerpt: string
   tags: string[]
+  seriesId?: string
   series?: string
   seriesPart?: number
   seriesLabel?: string
 }
 
-function parseSeries(frontmatter: PostFrontmatter): SeriesInfo | undefined {
-  if (!frontmatter.series || frontmatter.seriesPart == null) return undefined
-  return {
-    title: frontmatter.series,
-    part: frontmatter.seriesPart,
-    label: frontmatter.seriesLabel,
+function parseSeries(frontmatter: PostFrontmatter, slug: string): SeriesInfo | undefined {
+  const { seriesId, series, seriesPart } = frontmatter
+  if (seriesId == null && series == null && seriesPart == null) return undefined
+  if (seriesId == null || series == null || seriesPart == null) {
+    console.warn(
+      `[blog] "${slug}" has incomplete series frontmatter — ` +
+        `seriesId, series, and seriesPart are all required. Ignoring series.`,
+    )
+    return undefined
   }
+  return { id: seriesId, title: series, part: seriesPart, label: frontmatter.seriesLabel }
 }
 
 function normalizeDate(date: string | Date): string {
@@ -103,7 +110,7 @@ export function getAllPostsMeta(): BlogPostMeta[] {
         excerpt: frontmatter.excerpt,
         tags: frontmatter.tags ?? [],
         readTime: computeReadTime(body),
-        series: parseSeries(frontmatter),
+        series: parseSeries(frontmatter, slug),
       }
     })
     .filter((p): p is BlogPostMeta => p !== null)
@@ -114,9 +121,9 @@ export function getAllPostsMeta(): BlogPostMeta[] {
  * All posts in a series, ordered by part. Returns [] when the series has
  * fewer than two posts (a lone post is not a series).
  */
-export function getSeriesParts(seriesTitle: string, currentSlug?: string): SeriesPart[] {
+export function getSeriesParts(seriesId: string, currentSlug?: string): SeriesPart[] {
   const parts = getAllPostsMeta()
-    .filter((p) => p.series?.title === seriesTitle)
+    .filter((p) => p.series?.id === seriesId)
     .sort((a, b) => a.series!.part - b.series!.part)
     .map((p) => ({
       slug: p.slug,
@@ -152,7 +159,7 @@ export async function getPostBySlug(slug: string): Promise<BlogPost | null> {
     excerpt: frontmatter.excerpt,
     tags: frontmatter.tags ?? [],
     readTime: computeReadTime(body),
-    series: parseSeries(frontmatter),
+    series: parseSeries(frontmatter, slug),
     contentHtml: String(processed),
   }
 }

--- a/lib/title.ts
+++ b/lib/title.ts
@@ -1,0 +1,36 @@
+/**
+ * Splits a post title into a main heading and an optional de-emphasized
+ * subtitle, using a spaced em-dash (" — ") as the editorial separator.
+ *
+ *   "Cross-checking ... the web — Part 1: the setup and the CIRCL finding"
+ *     -> { main: "Cross-checking ... the web",
+ *          part: "Part 1",
+ *          subtitle: "the setup and the CIRCL finding" }
+ *
+ * Titles without the separator are returned unchanged ({ main: title }),
+ * so non-series / short titles render exactly as before.
+ */
+export interface TitleParts {
+  main: string
+  /** e.g. "Part 1" — present only when the subtitle leads with a part marker. */
+  part?: string
+  /** Remainder after the part marker, or the whole tail when there's no marker. */
+  subtitle?: string
+}
+
+const SEPARATOR = ' — ' // space + em-dash + space
+const PART_PATTERN = /^Part\s+(\d+)\s*[:–—.-]?\s*(.*)$/i
+
+export function splitTitle(title: string): TitleParts {
+  const idx = title.indexOf(SEPARATOR)
+  if (idx === -1) return { main: title }
+
+  const main = title.slice(0, idx)
+  const tail = title.slice(idx + SEPARATOR.length).trim()
+
+  const m = tail.match(PART_PATTERN)
+  if (m) {
+    return { main, part: `Part ${m[1]}`, subtitle: m[2] ? m[2].trim() : undefined }
+  }
+  return { main, subtitle: tail || undefined }
+}


### PR DESCRIPTION
## Heads-up: this also re-lands the series nav

While branching off `master` I found that **the series-nav work from #25 never reached `master`.** #25 was based on the intermediate branch `claude/mlkem-blog-multipart-split`; #24 merged an *earlier* snapshot of that branch into master, so when #25 later merged into the (now-superseded) intermediate branch, its changes were stranded there. `origin/master` currently has only the 3-part split — no `SeriesNav.tsx`, no `seriesId` frontmatter — so the live blog still shows the old inline `**Part 1** | …` markdown nav bars.

Per your call, this is **one combined PR** off master that:
1. **Re-lands the reviewed series-nav work** (the exact, already-approved commits `0baf596` + `a53018c` from #25 — styled `SeriesNav`/`SeriesPager`, `getSeriesParts`, `seriesId` frontmatter, inline-nav removal).
2. **Adds the new title-styling fix** on top.

If you'd instead prefer the series nav re-landed as its own PR, say the word and I'll split them.

---

## Title styling (the actual request)

Long titles with a ` — Part N: …` tail rendered as one uniform bold block, so the subtitle shouted as loudly as the title. This de-emphasizes the tail and improves wrapping for all long titles. Specced by an independent UX-designer pass first.

```
BEFORE                                   AFTER
Cross-checking the post-quantum KEM      Cross-checking the post-quantum KEM
behind the web — Part 1: the setup       behind the web
and the CIRCL finding                    
(all text-5xl bold)                      PART 1                    ← small mono accent
                                         the setup and the CIRCL   ← text-xl muted, regular
                                         finding
```

### Changes
- **`lib/title.ts`** — `splitTitle()` parses a title on the spaced em-dash `" — "` into `{ main, part?, subtitle? }`. Titles without it (the 2017 trio, every non-series post) are returned unchanged.
- **`components/PostTitle.tsx`** — one shared renderer:
  - `variant="full"` (post H1): stacked main + small accent **"Part N"** kicker + muted subtitle.
  - `variant="inline"` (blog index + Related Posts): main with the tail dimmed inline, to keep cards compact.
- **General polish** on all titles: `text-balance`, tighter leading, `max-w-3xl` measure on the H1.

### Accessibility / SEO
Stays a **single `<h1>`/`<h2>`/`<h3>`** — the split is only inner `<span>`s, with `sr-only` separators so the heading's text content reconstructs the **exact original title**. Verified in the built HTML: the H1's accessible text is `"Cross-checking the post-quantum KEM behind the web — Part 1: the setup and the CIRCL finding"`, byte-identical to `post.title`. `<title>`/OpenGraph/sitemap read `post.title` directly and are untouched. Hierarchy is encoded by size+weight+position, not color alone; all semantic tokens work in light and dark.

### Verification
`tsc`, `eslint`, `prettier` (`npm run check`), and `next build` (35 static pages) all green. Confirmed non-series / em-dash-free titles render as a plain single span, and the series nav still renders ("Part 1 of 3", "You are here").

https://claude.ai/code/session_0176Wuynx2kSmZAv7bb8P4Ho

---
_Generated by [Claude Code](https://claude.ai/code/session_0176Wuynx2kSmZAv7bb8P4Ho)_