### PR TITLE
content: refresh portfolio to highlight current work

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -11,12 +11,14 @@ export const metadata: Metadata = {
     template: '%s — Bhargava Shastry',
   },
   description:
-    'Security engineer at the Ethereum Foundation and indie security researcher specializing in smart contract security, fuzzing, and blockchain technology.',
+    'Security engineer at the Ethereum Foundation and indie security researcher specializing in protocol security, differential fuzzing, and Ethereum client testing.',
   keywords: [
     'security engineer',
     'ethereum',
     'blockchain',
-    'smart contracts',
+    'protocol security',
+    'differential fuzzing',
+    'bug bounty',
     'fuzzing',
     'security research',
   ],

--- a/components/About.tsx
+++ b/components/About.tsx
@@ -2,38 +2,36 @@
 
 export default function About() {
   const stats = [
-    { label: 'Years of Experience', value: '8+' },
+    { label: 'Years of Experience', value: '10+' },
     { label: 'Open Source Projects', value: '20+' },
     { label: 'Security Vulnerabilities Found', value: '50+' },
     { label: 'Community Contributions', value: '1000+' },
   ]
 
   const expertise = [
-    'Smart Contract Security',
-    'Fuzzing & Testing',
-    'Protocol Security',
-    'Static Analysis',
+    'Differential Fuzzing',
+    'Ethereum Protocol Security',
+    'Bug Bounty Triage',
     'Vulnerability Research',
-    'Open Source Development',
+    'Post-Quantum Cryptography',
+    'AI-Assisted Security Tooling',
   ]
 
   const technologies = [
-    'Solidity',
+    'Go',
     'Rust',
     'C++',
     'Python',
-    'Go',
-    'JavaScript',
-    'LLVM',
-    'AFL',
-    'Foundry',
-    'Hardhat',
-    'Docker',
-    'Git',
+    'Solidity',
     'Ethereum',
     'EVM',
-    'DeFi',
-    'Smart Contracts',
+    'goevmlab',
+    'libFuzzer',
+    'cargo-fuzz',
+    'AFL',
+    'Foundry',
+    'Docker',
+    'LLM Agents',
   ]
 
   return (
@@ -52,21 +50,23 @@ export default function About() {
                 Security Engineer & Researcher
               </h3>
               <p className="mb-4 leading-relaxed text-muted">
-                I'm a security engineer at the Ethereum Foundation and an independent security
-                researcher with a deep passion for blockchain technology and smart contract
-                security. My work focuses on identifying vulnerabilities, developing security tools,
-                and contributing to the overall security posture of decentralized systems.
+                I'm a security engineer at the Ethereum Foundation working on protocol security for
+                the execution layer. My day-to-day is differential fuzzing of Ethereum clients,
+                hard-fork readiness testing, and technical evaluation of submissions to the Ethereum
+                Foundation's bug bounty program.
               </p>
               <p className="mb-4 leading-relaxed text-muted">
-                With over 300 commits to the Solidity compiler and contributions to numerous
-                critical projects, I've been at the forefront of blockchain security research. My
-                expertise spans fuzzing, static analysis, protocol security, and vulnerability
-                discovery.
+                I came to Ethereum through compiler security — 300+ commits to the Solidity
+                compiler's fuzzing and testing infrastructure — and before that a Ph.D. on fuzzing
+                and static analysis at TU Berlin. That background in oracle-driven testing shapes my
+                client work today: if two independent implementations disagree, at least one of them
+                is wrong.
               </p>
               <p className="leading-relaxed text-muted">
-                I believe in the power of open-source collaboration and have contributed to projects
-                like Google's OSS-Fuzz, various Ethereum clients, and developed specialized security
-                tools that are used by the broader blockchain community.
+                I work in the open where I can: upstream fixes merged in Erigon, Nethermind, revm,
+                and the executable Ethereum specs, contributions to Google's OSS-Fuzz, and a blog
+                about differential testing — most recently cross-checking post-quantum cryptography
+                implementations against each other.
               </p>
             </div>
 

--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -4,7 +4,7 @@ import { ArrowDown } from 'lucide-react'
 import portfolioData from '@/data/portfolio.json'
 
 const stats = [
-  { value: '8+', label: 'years' },
+  { value: '10+', label: 'years' },
   { value: '20+', label: 'projects' },
   { value: '50+', label: 'vulnerabilities' },
   { value: '1000+', label: 'contributions' },

--- a/components/Projects.tsx
+++ b/components/Projects.tsx
@@ -1,9 +1,25 @@
-import { Shield, Code, Network, Bug, Globe, Wallet, ExternalLink, Github, Lock } from 'lucide-react'
+import {
+  Shield,
+  Code,
+  Network,
+  Bug,
+  Globe,
+  Wallet,
+  Crosshair,
+  Atom,
+  Bot,
+  ExternalLink,
+  Github,
+  Lock,
+} from 'lucide-react'
 import portfolioData from '@/data/portfolio.json'
 import githubStats from '@/data/github-stats.json'
 
 const themeIcons: Record<string, React.ReactNode> = {
   'protocol-security': <Shield size={16} />,
+  'bug-bounty': <Crosshair size={16} />,
+  'post-quantum': <Atom size={16} />,
+  'ai-security': <Bot size={16} />,
   'compiler-security': <Code size={16} />,
   'p2p-networking': <Network size={16} />,
   'fuzzing-infra': <Bug size={16} />,

--- a/data/portfolio.json
+++ b/data/portfolio.json
@@ -151,7 +151,7 @@
       "title": "Compiler Security",
       "description": "Core contributor to the Solidity compiler's testing infrastructure, with 300+ commits focused on fuzzing and correctness testing.",
       "tags": ["C++", "Solidity"],
-      "period": "2018 - Present",
+      "period": "2018 - 2022",
       "highlights": [
         "303 commits to the Solidity compiler, primarily in fuzzing and testing",
         "Built ABI encoder v2 differential fuzzer",

--- a/data/portfolio.json
+++ b/data/portfolio.json
@@ -99,7 +99,7 @@
       "title": "Bug Bounty Triage",
       "description": "Technical evaluator for the Ethereum Foundation bug bounty program: reproducing, assessing, and routing reported vulnerabilities across execution- and consensus-layer clients.",
       "tags": ["Go", "Python"],
-      "period": "2025 - Present",
+      "period": "2026 - Present",
       "highlights": [
         "Evaluate submissions for consensus, finality, and denial-of-service impact to assign severity",
         "Reproduce reported issues and confirm cross-client blast radius with differential test harnesses",
@@ -138,7 +138,7 @@
       "title": "AI-Assisted Vulnerability Research",
       "description": "Agentic systems that put LLMs to work on Ethereum client security: deterministic orchestration, auditable logs, and human review at the decision points.",
       "tags": ["Python", "Go"],
-      "period": "2025 - Present",
+      "period": "2026 - Present",
       "highlights": [
         "Agent frameworks that decompose vulnerability research into context building, harness generation, PoC validation, and triage",
         "Autonomous audit pipelines run against Ethereum client codebases in sandboxed environments",

--- a/data/portfolio.json
+++ b/data/portfolio.json
@@ -18,7 +18,7 @@
       "title": "Security Engineer",
       "company": "Ethereum Foundation",
       "period": "2019 - Present",
-      "description": "Conducting security research and development for Ethereum protocol, focusing on smart contract security, consensus mechanisms, and protocol-level vulnerabilities."
+      "description": "Protocol security for Ethereum: differential fuzzing of execution clients, hard-fork readiness testing, and technical evaluation of bug bounty submissions across execution- and consensus-layer clients."
     },
     {
       "title": "Independent Security Researcher",
@@ -65,7 +65,8 @@
       "Protocol Security",
       "Differential Fuzzing",
       "Consensus Client Testing",
-      "Smart Contract Auditing",
+      "Bug Bounty Triage",
+      "Post-Quantum Cryptography",
       "Static Analysis"
     ],
     "blockchain": ["Ethereum", "EVM", "Execution Layer", "Consensus Layer"],
@@ -75,18 +76,75 @@
     {
       "id": "protocol-security",
       "title": "Ethereum Protocol Security",
-      "description": "Differential fuzzing and testing tools for validating EIP implementations and consensus-critical code across Ethereum execution layer clients.",
-      "tags": ["Go", "Solidity", "Python"],
+      "description": "Differential fuzzing and hard-fork readiness testing across Ethereum execution clients — finding consensus divergences before they reach mainnet.",
+      "tags": ["Go", "Rust", "Python"],
       "period": "2019 - Present",
       "highlights": [
-        "Built differential fuzzers for EIP-7702 (account abstraction) across geth, Nethermind, and Besu",
-        "Developed PrecompileFuzzer for testing EVM precompile implementations targeting the Prague hard fork",
-        "Created EthFuzzNet, an Ethereum network resilience testing framework",
-        "33 commits to goevmlab for EVM trace analysis and test generation"
+        "Coverage-guided differential fuzzing of state-test execution across geth, Besu, Nethermind, Erigon, and revm, built on goevmlab",
+        "Hard-fork readiness testing for upcoming upgrades: gas repricing, block-level access lists, and new EIP semantics validated against the executable specs",
+        "Upstream fixes merged in Erigon, Nethermind, revm, and ethereum/execution-specs",
+        "Earlier: EIP-7702 differential fuzzers across geth, Nethermind, and Besu; PrecompileFuzzer for the Prague hard fork; EthFuzzNet network-resilience testing"
       ],
       "links": [
-        { "label": "goevmlab", "url": "https://github.com/holiman/goevmlab", "type": "github" }
+        { "label": "goevmlab", "url": "https://github.com/holiman/goevmlab", "type": "github" },
+        {
+          "label": "execution-specs",
+          "url": "https://github.com/ethereum/execution-specs",
+          "type": "github"
+        }
       ]
+    },
+    {
+      "id": "bug-bounty",
+      "title": "Bug Bounty Triage",
+      "description": "Technical evaluator for the Ethereum Foundation bug bounty program: reproducing, assessing, and routing reported vulnerabilities across execution- and consensus-layer clients.",
+      "tags": ["Go", "Python"],
+      "period": "2025 - Present",
+      "highlights": [
+        "Evaluate submissions for consensus, finality, and denial-of-service impact to assign severity",
+        "Reproduce reported issues and confirm cross-client blast radius with differential test harnesses",
+        "Built internal tooling that manages the submission-to-triage workflow end to end"
+      ],
+      "links": [
+        { "label": "Ethereum Bug Bounty", "url": "https://bounty.ethereum.org", "type": "external" }
+      ]
+    },
+    {
+      "id": "post-quantum",
+      "title": "Post-Quantum Cryptography",
+      "description": "Differential testing of post-quantum standards: cross-checking independent ML-KEM (FIPS 203) and ML-DSA (FIPS 204) implementations against each other.",
+      "tags": ["C", "Rust"],
+      "period": "2026 - Present",
+      "highlights": [
+        "Built a coverage-guided differential fuzzer co-linking mlkem-native, BoringSSL, and libcrux",
+        "Functional-equivalence and constant-time checks across implementations",
+        "Published a four-part blog series on the approach and results"
+      ],
+      "links": [
+        {
+          "label": "ML-KEM series",
+          "url": "/blog/cross-checking-post-quantum-kem",
+          "type": "external"
+        },
+        {
+          "label": "ML-DSA post",
+          "url": "/blog/cross-checking-post-quantum-signature",
+          "type": "external"
+        }
+      ]
+    },
+    {
+      "id": "ai-security",
+      "title": "AI-Assisted Vulnerability Research",
+      "description": "Agentic systems that put LLMs to work on Ethereum client security: deterministic orchestration, auditable logs, and human review at the decision points.",
+      "tags": ["Python", "Go"],
+      "period": "2025 - Present",
+      "highlights": [
+        "Agent frameworks that decompose vulnerability research into context building, harness generation, PoC validation, and triage",
+        "Autonomous audit pipelines run against Ethereum client codebases in sandboxed environments",
+        "LLM-assisted severity assessment integrated into the bug bounty triage workflow"
+      ],
+      "links": []
     },
     {
       "id": "compiler-security",


### PR DESCRIPTION
## Why

The site led with Solidity-compiler and smart-contract security work from 2018-2020, while the last two years of work — cross-client differential fuzzing, hard-fork readiness testing, EF bug bounty evaluation, post-quantum crypto cross-checking — appeared nowhere except the blog.

## What changed

**`data/portfolio.json`**
- **Ethereum Protocol Security** theme rewritten: coverage-guided differential fuzzing of state-test execution across geth/Besu/Nethermind/Erigon/revm, hard-fork readiness (gas repricing, block-level access lists), upstream fixes. Old highlights (EIP-7702, PrecompileFuzzer, EthFuzzNet) kept as an "Earlier" line.
- New **Bug Bounty Triage** theme (2025 – Present): technical evaluation of EF bug bounty submissions — severity assessment, cross-client reproduction, internal workflow tooling. Links to bounty.ethereum.org.
- New **Post-Quantum Cryptography** theme (2026 – Present): ML-KEM/ML-DSA differential testing, linking the published four-part blog series.
- New **AI-Assisted Vulnerability Research** theme (2025 – Present): agentic audit tooling, described at a deliberately high level.
- EF experience entry (feeds the CV, not the site) and security skills updated to match.

**`components/About.tsx`** — bio rewritten to lead with current execution-layer work and bounty evaluation; compiler/Ph.D. history moved to background context. Expertise and technology chips refreshed (dropped DeFi/Hardhat/JavaScript-era chips).

**`components/Hero.tsx`** — years counter 8+ → 10+.

**`components/Projects.tsx`** — icons for the three new theme ids.

**`app/layout.tsx`** — SEO description/keywords now say protocol security / differential fuzzing / bug bounty instead of smart contracts.

## Verification

- Every "merged upstream" claim was verified against GitHub: Erigon #18121 #17290, Nethermind #11809 #11576 #10205, revm #3319, execution-specs #3011 — all MERGED, all authored by @bshastry.
- `npm run check` (typecheck + lint + prettier) and `npm run build` pass locally.

## Deliberately excluded (private/sensitive)

No bounty submitter data, no unfixed findings or PoC details, no private fork names or internal framework codenames, no devnet exploit specifics. Everything is at the level already public in the Berlin Ethereum Day talk and the blog.

## For you to sanity-check before merging

1. **Bug bounty start year**: earliest local evidence is 2025, so the theme says "2025 – Present" — adjust if you started evaluating earlier.
2. **Years counter**: bumped to 10+ (defensible from 2017 independent research; 15+ would also be true counting Fraunhofer 2011). Pick your preferred framing.
3. **Compiler Security theme still says "2018 – Present"** — left untouched; change to a closed range if you no longer contribute.
4. `data/github-stats.json` (private-repo badges) was last generated 2026-04-13; rerun `scripts/update-stats.mjs` if you want fresh counts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)