### PR TITLE
Per-page SEO, RSS feed, contact section, accurate legal copy, and mobile render fixes

### DIFF
--- a/app/blog/BlogIndexClient.tsx
+++ b/app/blog/BlogIndexClient.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect } from 'react'
 import Link from 'next/link'
-import { Calendar, Clock, ArrowLeft, Search, Tag } from 'lucide-react'
+import { Calendar, Clock, ArrowLeft, Search, Tag, Rss } from 'lucide-react'
 import type { BlogPostMeta } from '@/lib/blog'
 import ThemeToggle from '@/components/ThemeToggle'
 import { PostTitle } from '@/components/PostTitle'
@@ -36,7 +36,7 @@ export default function BlogIndexClient({ posts }: BlogIndexClientProps) {
   }, [searchTerm, selectedTag, posts])
 
   return (
-    <div className="min-h-screen bg-bg">
+    <main id="main-content" className="min-h-screen bg-bg">
       <div className="border-b border-line">
         <div className="container-max section-padding py-8">
           <div className="mb-6 flex items-center justify-between">
@@ -58,6 +58,13 @@ export default function BlogIndexClient({ posts }: BlogIndexClientProps) {
               security, and vulnerability research. Sharing knowledge from years of security
               engineering experience.
             </p>
+            <a
+              href="/feed.xml"
+              className="link-accent mt-4 inline-flex items-center text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+            >
+              <Rss size={14} className="mr-2" />
+              Subscribe via RSS
+            </a>
           </div>
 
           <div className="mb-8 flex flex-col gap-4 md:flex-row">
@@ -110,11 +117,13 @@ export default function BlogIndexClient({ posts }: BlogIndexClientProps) {
                 <div className="mb-4 flex flex-col md:flex-row md:items-center md:justify-between">
                   <div className="mb-2 flex items-center text-sm text-faint md:mb-0">
                     <Calendar size={16} className="mr-2" />
-                    {new Date(post.date).toLocaleDateString('en-US', {
-                      year: 'numeric',
-                      month: 'long',
-                      day: 'numeric',
-                    })}
+                    <time dateTime={post.date}>
+                      {new Date(post.date).toLocaleDateString('en-US', {
+                        year: 'numeric',
+                        month: 'long',
+                        day: 'numeric',
+                      })}
+                    </time>
                     <Clock size={16} className="ml-4 mr-2" />
                     {post.readTime}
                   </div>
@@ -154,6 +163,6 @@ export default function BlogIndexClient({ posts }: BlogIndexClientProps) {
           </div>
         )}
       </div>
-    </div>
+    </main>
   )
 }

--- a/app/blog/[slug]/BlogPostClient.tsx
+++ b/app/blog/[slug]/BlogPostClient.tsx
@@ -41,7 +41,7 @@ export default function BlogPostClient({
     .slice(0, 2)
 
   return (
-    <div className="min-h-screen bg-bg">
+    <main id="main-content" className="min-h-screen bg-bg">
       <div className="border-b border-line">
         <div className="container-max section-padding py-8">
           <div className="mb-6 flex items-center justify-between">
@@ -72,11 +72,13 @@ export default function BlogPostClient({
             <div className="flex flex-col md:flex-row md:items-center md:justify-between">
               <div className="mb-4 flex items-center text-sm text-faint md:mb-0">
                 <Calendar size={16} className="mr-2" />
-                {new Date(post.date).toLocaleDateString('en-US', {
-                  year: 'numeric',
-                  month: 'long',
-                  day: 'numeric',
-                })}
+                <time dateTime={post.date}>
+                  {new Date(post.date).toLocaleDateString('en-US', {
+                    year: 'numeric',
+                    month: 'long',
+                    day: 'numeric',
+                  })}
+                </time>
                 <Clock size={16} className="ml-4 mr-2" />
                 {post.readTime}
               </div>
@@ -97,6 +99,24 @@ export default function BlogPostClient({
       <div className="container-max section-padding py-12">
         <div className="mx-auto max-w-4xl">
           {seriesTitle && <SeriesNav title={seriesTitle} parts={seriesParts} />}
+
+          {post.headings.length >= 3 && (
+            <nav aria-label="Table of contents" className="mb-10 border-l-2 border-line py-1 pl-6">
+              <p className="eyebrow mb-3">On this page</p>
+              <ul className="space-y-2">
+                {post.headings.map((heading) => (
+                  <li key={heading.id}>
+                    <a
+                      href={`#${heading.id}`}
+                      className="text-sm text-muted transition-colors hover:text-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+                    >
+                      {heading.text}
+                    </a>
+                  </li>
+                ))}
+              </ul>
+            </nav>
+          )}
 
           <article>
             <div
@@ -123,11 +143,13 @@ export default function BlogPostClient({
                     <p className="mb-3 text-sm text-muted">{rp.excerpt}</p>
                     <div className="flex items-center text-sm text-faint">
                       <Calendar size={14} className="mr-1" />
-                      {new Date(rp.date).toLocaleDateString('en-US', {
-                        year: 'numeric',
-                        month: 'short',
-                        day: 'numeric',
-                      })}
+                      <time dateTime={rp.date}>
+                        {new Date(rp.date).toLocaleDateString('en-US', {
+                          year: 'numeric',
+                          month: 'short',
+                          day: 'numeric',
+                        })}
+                      </time>
                       <Clock size={14} className="ml-3 mr-1" />
                       {rp.readTime}
                     </div>
@@ -138,6 +160,6 @@ export default function BlogPostClient({
           )}
         </div>
       </div>
-    </div>
+    </main>
   )
 }

--- a/app/blog/[slug]/opengraph-image.tsx
+++ b/app/blog/[slug]/opengraph-image.tsx
@@ -1,0 +1,58 @@
+import { ImageResponse } from 'next/og'
+import { getAllSlugs, getPostBySlug } from '@/lib/blog'
+
+export const dynamic = 'force-static'
+
+export function generateStaticParams() {
+  return getAllSlugs().map((slug) => ({ slug }))
+}
+// Note: intentionally NOT declaring `export const runtime = 'edge'` — see
+// app/opengraph-image.tsx. `next/og` works at build time in the default
+// Node runtime when the static export target is set.
+
+export const alt = 'Blog post by Bhargava Shastry'
+export const size = { width: 1200, height: 630 }
+export const contentType = 'image/png'
+
+function formatDate(date: string): string {
+  return new Date(`${date}T00:00:00Z`).toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+    timeZone: 'UTC',
+  })
+}
+
+export default async function OGImage({ params }: { params: Promise<{ slug: string }> }) {
+  const { slug } = await params
+  const post = await getPostBySlug(slug)
+  const title = post?.title ?? 'Blog'
+  // Long titles get a smaller type size so they stay inside the canvas.
+  const titleSize = title.length > 70 ? 52 : title.length > 45 ? 62 : 72
+
+  return new ImageResponse(
+    <div
+      style={{
+        width: '100%',
+        height: '100%',
+        display: 'flex',
+        flexDirection: 'column',
+        justifyContent: 'space-between',
+        padding: '80px',
+        background: 'linear-gradient(135deg, #0f172a 0%, #1e293b 60%, #312e81 100%)',
+        color: 'white',
+        fontFamily: 'sans-serif',
+      }}
+    >
+      <div style={{ display: 'flex', flexDirection: 'column' }}>
+        <div style={{ fontSize: 28, opacity: 0.7, marginBottom: 40 }}>bshastry.github.io/blog</div>
+        <div style={{ fontSize: titleSize, fontWeight: 800, lineHeight: 1.1 }}>{title}</div>
+      </div>
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+        <div style={{ fontSize: 32, opacity: 0.92 }}>Bhargava Shastry</div>
+        <div style={{ fontSize: 28, opacity: 0.7 }}>{post ? formatDate(post.date) : ''}</div>
+      </div>
+    </div>,
+    { ...size },
+  )
+}

--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -1,6 +1,10 @@
+import type { Metadata } from 'next'
 import { notFound } from 'next/navigation'
 import { getAllSlugs, getAllPostsMeta, getPostBySlug, getSeriesParts } from '@/lib/blog'
 import BlogPostClient from './BlogPostClient'
+
+const SITE_URL = 'https://bshastry.github.io'
+const AUTHOR = 'Bhargava Shastry'
 
 interface BlogPostPageProps {
   params: Promise<{ slug: string }>
@@ -10,18 +14,76 @@ export function generateStaticParams() {
   return getAllSlugs().map((slug) => ({ slug }))
 }
 
+export async function generateMetadata({ params }: BlogPostPageProps): Promise<Metadata> {
+  const { slug } = await params
+  const post = await getPostBySlug(slug)
+  if (!post) return {}
+
+  const canonical = `/blog/${post.slug}/`
+  return {
+    title: post.title,
+    description: post.excerpt,
+    keywords: post.tags,
+    alternates: { canonical },
+    openGraph: {
+      type: 'article',
+      url: `${SITE_URL}${canonical}`,
+      siteName: AUTHOR,
+      title: post.title,
+      description: post.excerpt,
+      publishedTime: `${post.date}T00:00:00.000Z`,
+      authors: [AUTHOR],
+      tags: post.tags,
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title: post.title,
+      description: post.excerpt,
+      creator: '@ibags',
+    },
+  }
+}
+
 export default async function BlogPostPage({ params }: BlogPostPageProps) {
   const { slug } = await params
   const post = await getPostBySlug(slug)
   if (!post) notFound()
   const allPosts = getAllPostsMeta()
   const seriesParts = post.series ? getSeriesParts(post.series.id, post.slug) : []
+
+  const jsonLd = {
+    '@context': 'https://schema.org',
+    '@type': 'BlogPosting',
+    headline: post.title,
+    description: post.excerpt,
+    datePublished: `${post.date}T00:00:00.000Z`,
+    keywords: post.tags.join(', '),
+    url: `${SITE_URL}/blog/${post.slug}/`,
+    mainEntityOfPage: `${SITE_URL}/blog/${post.slug}/`,
+    author: {
+      '@type': 'Person',
+      name: AUTHOR,
+      url: SITE_URL,
+    },
+    isPartOf: {
+      '@type': 'Blog',
+      name: `${AUTHOR} — Blog`,
+      url: `${SITE_URL}/blog/`,
+    },
+  }
+
   return (
-    <BlogPostClient
-      post={post}
-      allPosts={allPosts}
-      seriesTitle={post.series?.title ?? null}
-      seriesParts={seriesParts}
-    />
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+      />
+      <BlogPostClient
+        post={post}
+        allPosts={allPosts}
+        seriesTitle={post.series?.title ?? null}
+        seriesParts={seriesParts}
+      />
+    </>
   )
 }

--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -1,5 +1,26 @@
+import type { Metadata } from 'next'
 import { getAllPostsMeta } from '@/lib/blog'
 import BlogIndexClient from './BlogIndexClient'
+
+export const metadata: Metadata = {
+  title: 'Blog',
+  description:
+    'Writing on fuzzing, Ethereum client security, post-quantum cryptography, and vulnerability research by Bhargava Shastry.',
+  alternates: {
+    canonical: '/blog/',
+    types: {
+      'application/rss+xml': [{ url: '/feed.xml', title: 'Bhargava Shastry — Blog' }],
+    },
+  },
+  openGraph: {
+    type: 'website',
+    url: 'https://bshastry.github.io/blog/',
+    siteName: 'Bhargava Shastry',
+    title: 'Blog — Bhargava Shastry',
+    description:
+      'Writing on fuzzing, Ethereum client security, post-quantum cryptography, and vulnerability research.',
+  },
+}
 
 export default function BlogPage() {
   const posts = getAllPostsMeta()

--- a/app/feed.xml/route.ts
+++ b/app/feed.xml/route.ts
@@ -1,0 +1,53 @@
+import { getAllPostsMeta } from '@/lib/blog'
+
+export const dynamic = 'force-static'
+
+const SITE_URL = 'https://bshastry.github.io'
+
+function escapeXml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;')
+}
+
+export async function GET() {
+  const posts = getAllPostsMeta()
+  const lastBuildDate = posts[0]
+    ? new Date(`${posts[0].date}T00:00:00Z`).toUTCString()
+    : new Date().toUTCString()
+
+  const items = posts
+    .map((post) => {
+      const url = `${SITE_URL}/blog/${post.slug}/`
+      return `    <item>
+      <title>${escapeXml(post.title)}</title>
+      <link>${url}</link>
+      <guid isPermaLink="true">${url}</guid>
+      <pubDate>${new Date(`${post.date}T00:00:00Z`).toUTCString()}</pubDate>
+      <description>${escapeXml(post.excerpt)}</description>
+${post.tags.map((tag) => `      <category>${escapeXml(tag)}</category>`).join('\n')}
+    </item>`
+    })
+    .join('\n')
+
+  const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+  <channel>
+    <title>Bhargava Shastry — Blog</title>
+    <link>${SITE_URL}/blog/</link>
+    <atom:link href="${SITE_URL}/feed.xml" rel="self" type="application/rss+xml"/>
+    <description>Writing on fuzzing, Ethereum client security, post-quantum cryptography, and vulnerability research.</description>
+    <language>en-us</language>
+    <lastBuildDate>${lastBuildDate}</lastBuildDate>
+${items}
+  </channel>
+</rss>
+`
+
+  return new Response(xml, {
+    headers: { 'Content-Type': 'application/rss+xml; charset=utf-8' },
+  })
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -25,6 +25,9 @@ export const metadata: Metadata = {
   authors: [{ name: 'Bhargava Shastry' }],
   alternates: {
     canonical: '/',
+    types: {
+      'application/rss+xml': [{ url: '/feed.xml', title: 'Bhargava Shastry — Blog' }],
+    },
   },
   openGraph: {
     type: 'website',
@@ -60,7 +63,15 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
       <head>
         <script dangerouslySetInnerHTML={{ __html: themeScript }} />
       </head>
-      <body className={inter.className}>{children}</body>
+      <body className={inter.className}>
+        <a
+          href="#main-content"
+          className="sr-only focus:not-sr-only focus:fixed focus:left-4 focus:top-4 focus:z-[100] focus:rounded focus:bg-accent focus:px-4 focus:py-2 focus:text-white"
+        >
+          Skip to content
+        </a>
+        {children}
+      </body>
     </html>
   )
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -6,8 +6,40 @@ import Findings from '@/components/Findings'
 import Talks from '@/components/Talks'
 import Writing from '@/components/Writing'
 import Publications from '@/components/Publications'
+import Contact from '@/components/Contact'
 import Footer from '@/components/Footer'
 import { getAllPostsMeta } from '@/lib/blog'
+
+const SITE_URL = 'https://bshastry.github.io'
+
+const personJsonLd = {
+  '@context': 'https://schema.org',
+  '@type': 'Person',
+  name: 'Bhargava Shastry',
+  url: SITE_URL,
+  jobTitle: 'Security Engineer',
+  worksFor: {
+    '@type': 'Organization',
+    name: 'Ethereum Foundation',
+  },
+  alumniOf: {
+    '@type': 'CollegeOrUniversity',
+    name: 'Technische Universität Berlin',
+  },
+  sameAs: [
+    'https://github.com/bshastry',
+    'https://twitter.com/ibags',
+    'https://linkedin.com/in/bshastry',
+    'https://scholar.google.com/citations?hl=en&authuser=2&user=lsdZxf8AAAAJ',
+  ],
+  knowsAbout: [
+    'Fuzzing',
+    'Ethereum protocol security',
+    'Differential testing',
+    'Post-quantum cryptography',
+    'Vulnerability research',
+  ],
+}
 
 export default function Home() {
   const posts = getAllPostsMeta()
@@ -17,16 +49,23 @@ export default function Home() {
     : null
 
   return (
-    <main className="min-h-screen">
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(personJsonLd) }}
+      />
       <Header />
-      <Hero latestPost={latestPost} />
-      <About />
-      <Projects />
-      <Findings />
-      <Talks />
-      <Writing posts={recentPosts} />
-      <Publications />
+      <main id="main-content" className="min-h-screen">
+        <Hero latestPost={latestPost} />
+        <About />
+        <Projects />
+        <Findings />
+        <Talks />
+        <Writing posts={recentPosts} />
+        <Publications />
+        <Contact />
+      </main>
       <Footer />
-    </main>
+    </>
   )
 }

--- a/app/privacy/page.tsx
+++ b/app/privacy/page.tsx
@@ -1,10 +1,22 @@
+import type { Metadata } from 'next'
 import Link from 'next/link'
-import { ArrowLeft, Shield, Eye, Database, Mail } from 'lucide-react'
+import { ArrowLeft, Shield } from 'lucide-react'
+import portfolioData from '@/data/portfolio.json'
+
+export const metadata: Metadata = {
+  title: 'Privacy',
+  description:
+    'Privacy notice for bshastry.github.io: a static site with no cookies, no analytics, and no contact forms.',
+  alternates: { canonical: '/privacy/' },
+}
+
+const LAST_UPDATED = 'July 18, 2026'
 
 export default function PrivacyPolicyPage() {
+  const { email } = portfolioData.personal
+
   return (
-    <div className="min-h-screen bg-bg">
-      {/* Header */}
+    <main id="main-content" className="min-h-screen bg-bg">
       <div className="border-b border-line">
         <div className="container-max section-padding py-8">
           <Link
@@ -17,194 +29,83 @@ export default function PrivacyPolicyPage() {
 
           <div className="mb-4 flex items-center">
             <Shield size={32} className="mr-3 text-faint" />
-            <h1 className="section-title">Privacy Policy</h1>
+            <h1 className="section-title">Privacy</h1>
           </div>
 
-          <p className="text-lg text-muted">
-            Last updated:{' '}
-            {new Date().toLocaleDateString('en-US', {
-              year: 'numeric',
-              month: 'long',
-              day: 'numeric',
-            })}
-          </p>
+          <p className="text-lg text-muted">Last updated: {LAST_UPDATED}</p>
         </div>
       </div>
 
-      {/* Content */}
       <div className="container-max section-padding py-12">
         <div className="mx-auto max-w-4xl">
           <div className="panel p-8 md:p-12">
             <div className="prose prose-lg max-w-none">
-              {/* Introduction */}
               <section className="mb-8">
-                <h2 className="mb-4 flex items-center text-2xl font-bold text-fg">
-                  <Eye size={24} className="mr-2 text-faint" />
-                  Introduction
-                </h2>
+                <h2 className="mb-4 text-2xl font-bold text-fg">The short version</h2>
                 <p className="leading-relaxed text-muted">
-                  This Privacy Policy describes how Bhargava Shastry ("I", "me", or "my") collects,
-                  uses, and protects your information when you visit this personal portfolio website
-                  (the "Service"). This policy applies to bshastry.github.io and any related
-                  services.
-                </p>
-                <p className="mt-4 leading-relaxed text-muted">
-                  As a security engineer, I am committed to protecting your privacy and being
-                  transparent about data practices. This website is designed with privacy in mind.
+                  This is a static personal website. It sets no cookies, runs no analytics or
+                  tracking scripts, and has no contact forms or accounts. I collect no personal data
+                  from your visit.
                 </p>
               </section>
 
-              {/* Information Collection */}
               <section className="mb-8">
-                <h2 className="mb-4 flex items-center text-2xl font-bold text-fg">
-                  <Database size={24} className="mr-2 text-faint" />
-                  Information I Collect
-                </h2>
-
-                <h3 className="mb-3 text-xl font-semibold text-fg">Information You Provide</h3>
-                <ul className="mb-6 list-inside list-disc space-y-2 text-muted">
-                  <li>Contact information when you reach out via email or contact forms</li>
-                  <li>Any messages or communications you send directly</li>
-                </ul>
-
-                <h3 className="mb-3 text-xl font-semibold text-fg">
-                  Automatically Collected Information
-                </h3>
-                <ul className="mb-6 list-inside list-disc space-y-2 text-muted">
-                  <li>Basic web analytics (via GitHub Pages hosting)</li>
-                  <li>Browser type and version</li>
-                  <li>Pages visited and time spent on the site</li>
-                  <li>Referring websites</li>
-                  <li>IP address (anonymized)</li>
-                </ul>
-
-                <div className="mb-6 border-l-2 border-accent bg-accent/10 p-4">
-                  <p className="text-muted">
-                    <strong>Note:</strong> This website is hosted on GitHub Pages and does not use
-                    cookies, tracking pixels, or third-party analytics services beyond what GitHub
-                    provides for basic site statistics.
-                  </p>
-                </div>
-              </section>
-
-              {/* How I Use Information */}
-              <section className="mb-8">
-                <h2 className="mb-4 text-2xl font-bold text-fg">How I Use Your Information</h2>
-                <ul className="list-inside list-disc space-y-2 text-muted">
-                  <li>To respond to your inquiries and communications</li>
-                  <li>To improve the website content and user experience</li>
-                  <li>To understand how visitors interact with the site</li>
-                  <li>To maintain the security and integrity of the website</li>
-                </ul>
-              </section>
-
-              {/* Information Sharing */}
-              <section className="mb-8">
-                <h2 className="mb-4 text-2xl font-bold text-fg">Information Sharing</h2>
-                <p className="mb-4 leading-relaxed text-muted">
-                  I do not sell, trade, or otherwise transfer your personal information to third
-                  parties. Information may only be shared in the following circumstances:
-                </p>
-                <ul className="list-inside list-disc space-y-2 text-muted">
-                  <li>With your explicit consent</li>
-                  <li>When required by law or legal process</li>
-                  <li>To protect the rights, property, or safety of myself or others</li>
-                </ul>
-              </section>
-
-              {/* Data Security */}
-              <section className="mb-8">
-                <h2 className="mb-4 text-2xl font-bold text-fg">Data Security</h2>
-                <p className="mb-4 leading-relaxed text-muted">
-                  As a security professional, I implement appropriate technical and organizational
-                  measures to protect your personal information:
-                </p>
-                <ul className="list-inside list-disc space-y-2 text-muted">
-                  <li>HTTPS encryption for all communications</li>
-                  <li>Minimal data collection practices</li>
-                  <li>Regular security reviews of the website</li>
-                  <li>Secure hosting infrastructure via GitHub Pages</li>
-                </ul>
-              </section>
-
-              {/* Third-Party Services */}
-              <section className="mb-8">
-                <h2 className="mb-4 text-2xl font-bold text-fg">Third-Party Services</h2>
-                <p className="mb-4 leading-relaxed text-muted">
-                  This website may contain links to external sites and services:
-                </p>
-                <ul className="list-inside list-disc space-y-2 text-muted">
-                  <li>
-                    <strong>GitHub:</strong> For hosting and version control
-                  </li>
-                  <li>
-                    <strong>Social Media:</strong> Links to LinkedIn, Twitter, and other platforms
-                  </li>
-                  <li>
-                    <strong>Academic Profiles:</strong> Links to Google Scholar, research
-                    publications
-                  </li>
-                </ul>
-                <p className="mt-4 leading-relaxed text-muted">
-                  These third-party services have their own privacy policies, which I encourage you
-                  to review.
-                </p>
-              </section>
-
-              {/* Your Rights */}
-              <section className="mb-8">
-                <h2 className="mb-4 text-2xl font-bold text-fg">Your Rights</h2>
-                <p className="mb-4 leading-relaxed text-muted">You have the right to:</p>
-                <ul className="list-inside list-disc space-y-2 text-muted">
-                  <li>Request information about data I have collected about you</li>
-                  <li>Request correction of inaccurate personal information</li>
-                  <li>Request deletion of your personal information</li>
-                  <li>Opt out of any future communications</li>
-                </ul>
-              </section>
-
-              {/* Contact Information */}
-              <section className="mb-8">
-                <h2 className="mb-4 flex items-center text-2xl font-bold text-fg">
-                  <Mail size={24} className="mr-2 text-faint" />
-                  Contact Me
-                </h2>
-                <p className="mb-4 leading-relaxed text-muted">
-                  If you have any questions about this Privacy Policy or your personal information,
-                  please contact me:
-                </p>
-                <div className="panel p-4">
-                  <p className="text-muted">
-                    <strong>Email:</strong> Available through the contact form on this website
-                  </p>
-                  <p className="text-muted">
-                    <strong>Response Time:</strong> I aim to respond within 48 hours
-                  </p>
-                </div>
-              </section>
-
-              {/* Updates */}
-              <section className="mb-8">
-                <h2 className="mb-4 text-2xl font-bold text-fg">Policy Updates</h2>
+                <h2 className="mb-4 text-2xl font-bold text-fg">What the site stores</h2>
                 <p className="leading-relaxed text-muted">
-                  I may update this Privacy Policy from time to time. Any changes will be posted on
-                  this page with an updated "Last updated" date. I encourage you to review this
-                  policy periodically for any changes.
+                  Your light/dark theme choice is saved in your browser&apos;s{' '}
+                  <code>localStorage</code>. It never leaves your device and you can clear it at any
+                  time through your browser settings.
                 </p>
               </section>
 
-              {/* Footer */}
-              <div className="mt-8 border-t border-line pt-6">
-                <p className="text-center text-sm text-faint">
-                  This privacy policy reflects my commitment to transparency and data protection as
-                  a security professional. For technical questions about website security, feel free
-                  to reach out.
+              <section className="mb-8">
+                <h2 className="mb-4 text-2xl font-bold text-fg">Hosting</h2>
+                <p className="leading-relaxed text-muted">
+                  The site is served by GitHub Pages. GitHub may log visitor IP addresses for
+                  security purposes, as described in the{' '}
+                  <a
+                    href="https://docs.github.com/en/site-policy/privacy-policies/github-general-privacy-statement"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="link-accent"
+                  >
+                    GitHub Privacy Statement
+                  </a>
+                  . I do not have access to per-visitor data from this logging.
                 </p>
-              </div>
+              </section>
+
+              <section className="mb-8">
+                <h2 className="mb-4 text-2xl font-bold text-fg">If you email me</h2>
+                <p className="leading-relaxed text-muted">
+                  The only way to contact me through this site is email (
+                  <a href={`mailto:${email}`} className="link-accent">
+                    {email}
+                  </a>
+                  ). I use your address and message solely to reply, and I don&apos;t share them
+                  with anyone.
+                </p>
+              </section>
+
+              <section className="mb-8">
+                <h2 className="mb-4 text-2xl font-bold text-fg">External links</h2>
+                <p className="leading-relaxed text-muted">
+                  Links to GitHub, YouTube, Google Scholar, and other external sites are governed by
+                  those services&apos; own privacy policies.
+                </p>
+              </section>
+
+              <section>
+                <h2 className="mb-4 text-2xl font-bold text-fg">Changes</h2>
+                <p className="leading-relaxed text-muted">
+                  If the site ever starts collecting data — for example, by adding analytics — this
+                  page will be updated first, with a new date above.
+                </p>
+              </section>
             </div>
           </div>
         </div>
       </div>
-    </div>
+    </main>
   )
 }

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,5 +1,5 @@
 import type { MetadataRoute } from 'next'
-import { getAllSlugs } from '@/lib/blog'
+import { getAllPostsMeta } from '@/lib/blog'
 export const dynamic = 'force-static'
 
 const BASE = 'https://bshastry.github.io'
@@ -7,12 +7,13 @@ const BASE = 'https://bshastry.github.io'
 export default function sitemap(): MetadataRoute.Sitemap {
   const staticRoutes: MetadataRoute.Sitemap = [
     { url: `${BASE}/`, changeFrequency: 'monthly', priority: 1 },
-    { url: `${BASE}/blog`, changeFrequency: 'weekly', priority: 0.9 },
-    { url: `${BASE}/privacy`, changeFrequency: 'yearly', priority: 0.3 },
-    { url: `${BASE}/terms`, changeFrequency: 'yearly', priority: 0.3 },
+    { url: `${BASE}/blog/`, changeFrequency: 'weekly', priority: 0.9 },
+    { url: `${BASE}/privacy/`, changeFrequency: 'yearly', priority: 0.3 },
+    { url: `${BASE}/terms/`, changeFrequency: 'yearly', priority: 0.3 },
   ]
-  const postRoutes: MetadataRoute.Sitemap = getAllSlugs().map((slug) => ({
-    url: `${BASE}/blog/${slug}`,
+  const postRoutes: MetadataRoute.Sitemap = getAllPostsMeta().map((post) => ({
+    url: `${BASE}/blog/${post.slug}/`,
+    lastModified: new Date(`${post.date}T00:00:00Z`),
     changeFrequency: 'yearly',
     priority: 0.7,
   }))

--- a/app/terms/page.tsx
+++ b/app/terms/page.tsx
@@ -1,10 +1,22 @@
+import type { Metadata } from 'next'
 import Link from 'next/link'
-import { ArrowLeft, FileText, Scale, AlertTriangle, Mail } from 'lucide-react'
+import { ArrowLeft, Scale } from 'lucide-react'
+import portfolioData from '@/data/portfolio.json'
 
-export default function TermsOfServicePage() {
+export const metadata: Metadata = {
+  title: 'Disclaimer',
+  description:
+    'Disclaimer for bshastry.github.io: personal views, no warranties, and responsible use of published security research.',
+  alternates: { canonical: '/terms/' },
+}
+
+const LAST_UPDATED = 'July 18, 2026'
+
+export default function DisclaimerPage() {
+  const { email } = portfolioData.personal
+
   return (
-    <div className="min-h-screen bg-bg">
-      {/* Header */}
+    <main id="main-content" className="min-h-screen bg-bg">
       <div className="border-b border-line">
         <div className="container-max section-padding py-8">
           <Link
@@ -17,223 +29,59 @@ export default function TermsOfServicePage() {
 
           <div className="mb-4 flex items-center">
             <Scale size={32} className="mr-3 text-faint" />
-            <h1 className="section-title">Terms of Service</h1>
+            <h1 className="section-title">Disclaimer</h1>
           </div>
 
-          <p className="text-lg text-muted">
-            Last updated:{' '}
-            {new Date().toLocaleDateString('en-US', {
-              year: 'numeric',
-              month: 'long',
-              day: 'numeric',
-            })}
-          </p>
+          <p className="text-lg text-muted">Last updated: {LAST_UPDATED}</p>
         </div>
       </div>
 
-      {/* Content */}
       <div className="container-max section-padding py-12">
         <div className="mx-auto max-w-4xl">
           <div className="panel p-8 md:p-12">
             <div className="prose prose-lg max-w-none">
-              {/* Introduction */}
               <section className="mb-8">
-                <h2 className="mb-4 flex items-center text-2xl font-bold text-fg">
-                  <FileText size={24} className="mr-2 text-faint" />
-                  Agreement to Terms
-                </h2>
+                <h2 className="mb-4 text-2xl font-bold text-fg">Personal views</h2>
                 <p className="leading-relaxed text-muted">
-                  By accessing and using this website (bshastry.github.io), you accept and agree to
-                  be bound by the terms and provision of this agreement. This is the personal
-                  portfolio website of Bhargava Shastry, Security Engineer at the Ethereum
-                  Foundation.
-                </p>
-                <p className="mt-4 leading-relaxed text-muted">
-                  If you do not agree to abide by the above, please do not use this service.
+                  This is my personal website. Everything published here — posts, findings, talks,
+                  and opinions — is my own and does not represent the position of the Ethereum
+                  Foundation or any other organization I work with, unless explicitly stated.
                 </p>
               </section>
 
-              {/* Use License */}
               <section className="mb-8">
-                <h2 className="mb-4 text-2xl font-bold text-fg">Use License</h2>
-                <p className="mb-4 leading-relaxed text-muted">
-                  Permission is granted to temporarily download one copy of the materials on this
-                  website for personal, non-commercial transitory viewing only. This is the grant of
-                  a license, not a transfer of title, and under this license you may not:
-                </p>
-                <ul className="mb-4 list-inside list-disc space-y-2 text-muted">
-                  <li>modify or copy the materials</li>
-                  <li>
-                    use the materials for any commercial purpose or for any public display
-                    (commercial or non-commercial)
-                  </li>
-                  <li>
-                    attempt to decompile or reverse engineer any software contained on the website
-                  </li>
-                  <li>remove any copyright or other proprietary notations from the materials</li>
-                </ul>
+                <h2 className="mb-4 text-2xl font-bold text-fg">Security research</h2>
                 <p className="leading-relaxed text-muted">
-                  This license shall automatically terminate if you violate any of these
-                  restrictions and may be terminated by me at any time. Upon terminating your
-                  viewing of these materials or upon the termination of this license, you must
-                  destroy any downloaded materials in your possession whether in electronic or
-                  printed format.
+                  Vulnerability write-ups and security research on this site are published for
+                  defensive and educational purposes, after coordinated disclosure where applicable.
+                  Don&apos;t use anything here to attack systems you are not authorized to test.
                 </p>
               </section>
 
-              {/* Content and Research */}
               <section className="mb-8">
-                <h2 className="mb-4 text-2xl font-bold text-fg">Content and Research</h2>
-                <p className="mb-4 leading-relaxed text-muted">
-                  This website contains information about security research, software engineering,
-                  and academic work. Please note:
-                </p>
-                <ul className="mb-4 list-inside list-disc space-y-2 text-muted">
-                  <li>
-                    Research content is provided for educational and informational purposes only
-                  </li>
-                  <li>Security research information should not be used for malicious purposes</li>
-                  <li>Code examples and technical content are provided "as is" without warranty</li>
-                  <li>
-                    Always follow responsible disclosure practices when dealing with security
-                    vulnerabilities
-                  </li>
-                </ul>
-
-                <div className="mb-6 border-l-2 border-accent bg-accent/10 p-4">
-                  <div className="flex items-start">
-                    <AlertTriangle size={20} className="mr-2 mt-1 flex-shrink-0 text-accent" />
-                    <div>
-                      <p className="font-semibold text-fg">Important Notice</p>
-                      <p className="mt-1 text-muted">
-                        Any security research or vulnerability information shared on this site is
-                        intended for defensive and educational purposes. Misuse of this information
-                        for malicious activities is strictly prohibited and may be illegal.
-                      </p>
-                    </div>
-                  </div>
-                </div>
-              </section>
-
-              {/* Disclaimer */}
-              <section className="mb-8">
-                <h2 className="mb-4 text-2xl font-bold text-fg">Disclaimer</h2>
-                <p className="mb-4 leading-relaxed text-muted">
-                  The materials on this website are provided on an 'as is' basis. I make no
-                  warranties, expressed or implied, and hereby disclaim and negate all other
-                  warranties including without limitation, implied warranties or conditions of
-                  merchantability, fitness for a particular purpose, or non-infringement of
-                  intellectual property or other violation of rights.
-                </p>
+                <h2 className="mb-4 text-2xl font-bold text-fg">No warranty</h2>
                 <p className="leading-relaxed text-muted">
-                  Further, I do not warrant or make any representations concerning the accuracy,
-                  likely results, or reliability of the use of the materials on its website or
-                  otherwise relating to such materials or on any sites linked to this site.
+                  Content, including code samples, is provided &quot;as is&quot; without warranty of
+                  any kind. Technical material can become outdated or contain errors, and I accept
+                  no liability for damages arising from its use. Links to external sites are
+                  provided for convenience and do not imply endorsement.
                 </p>
               </section>
 
-              {/* Limitations */}
-              <section className="mb-8">
-                <h2 className="mb-4 text-2xl font-bold text-fg">Limitations</h2>
+              <section>
+                <h2 className="mb-4 text-2xl font-bold text-fg">Questions</h2>
                 <p className="leading-relaxed text-muted">
-                  In no event shall Bhargava Shastry or his employers be liable for any damages
-                  (including, without limitation, damages for loss of data or profit, or due to
-                  business interruption) arising out of the use or inability to use the materials on
-                  this website, even if I or my authorized representative has been notified orally
-                  or in writing of the possibility of such damage. Because some jurisdictions do not
-                  allow limitations on implied warranties, or limitations of liability for
-                  consequential or incidental damages, these limitations may not apply to you.
+                  If anything here seems wrong or you have questions about this site, email me at{' '}
+                  <a href={`mailto:${email}`} className="link-accent">
+                    {email}
+                  </a>
+                  .
                 </p>
               </section>
-
-              {/* Professional Disclaimer */}
-              <section className="mb-8">
-                <h2 className="mb-4 text-2xl font-bold text-fg">Professional Disclaimer</h2>
-                <p className="mb-4 leading-relaxed text-muted">
-                  The views and opinions expressed on this website are my own and do not necessarily
-                  reflect the official policy or position of the Ethereum Foundation or any other
-                  organization I am affiliated with.
-                </p>
-                <p className="leading-relaxed text-muted">
-                  Any content related to security research, vulnerability disclosure, or technical
-                  analysis represents my personal research and should not be attributed to my
-                  employers unless explicitly stated otherwise.
-                </p>
-              </section>
-
-              {/* Accuracy of Materials */}
-              <section className="mb-8">
-                <h2 className="mb-4 text-2xl font-bold text-fg">Accuracy of Materials</h2>
-                <p className="leading-relaxed text-muted">
-                  The materials appearing on this website could include technical, typographical, or
-                  photographic errors. I do not warrant that any of the materials on its website are
-                  accurate, complete, or current. I may make changes to the materials contained on
-                  its website at any time without notice. However, I do not make any commitment to
-                  update the materials.
-                </p>
-              </section>
-
-              {/* Links */}
-              <section className="mb-8">
-                <h2 className="mb-4 text-2xl font-bold text-fg">Links</h2>
-                <p className="leading-relaxed text-muted">
-                  I have not reviewed all of the sites linked to this website and am not responsible
-                  for the contents of any such linked site. The inclusion of any link does not imply
-                  endorsement by me of the site. Use of any such linked website is at the user's own
-                  risk.
-                </p>
-              </section>
-
-              {/* Modifications */}
-              <section className="mb-8">
-                <h2 className="mb-4 text-2xl font-bold text-fg">Modifications</h2>
-                <p className="leading-relaxed text-muted">
-                  I may revise these terms of service for its website at any time without notice. By
-                  using this website, you are agreeing to be bound by the then current version of
-                  these terms of service.
-                </p>
-              </section>
-
-              {/* Governing Law */}
-              <section className="mb-8">
-                <h2 className="mb-4 text-2xl font-bold text-fg">Governing Law</h2>
-                <p className="leading-relaxed text-muted">
-                  These terms and conditions are governed by and construed in accordance with the
-                  laws of Germany and you irrevocably submit to the exclusive jurisdiction of the
-                  courts in that State or location.
-                </p>
-              </section>
-
-              {/* Contact Information */}
-              <section className="mb-8">
-                <h2 className="mb-4 flex items-center text-2xl font-bold text-fg">
-                  <Mail size={24} className="mr-2 text-faint" />
-                  Contact Information
-                </h2>
-                <p className="mb-4 leading-relaxed text-muted">
-                  If you have any questions about these Terms of Service, please contact me:
-                </p>
-                <div className="panel p-4">
-                  <p className="text-muted">
-                    <strong>Email:</strong> Available through the contact form on this website
-                  </p>
-                  <p className="text-muted">
-                    <strong>Response Time:</strong> I aim to respond within 48 hours
-                  </p>
-                </div>
-              </section>
-
-              {/* Footer */}
-              <div className="mt-8 border-t border-line pt-6">
-                <p className="text-center text-sm text-faint">
-                  These terms of service are designed to protect both visitors and the content
-                  creator while promoting responsible use of security research information.
-                </p>
-              </div>
             </div>
           </div>
         </div>
       </div>
-    </div>
+    </main>
   )
 }

--- a/components/Contact.tsx
+++ b/components/Contact.tsx
@@ -1,0 +1,71 @@
+import { Mail, Mic, FlaskConical, ShieldCheck, Key } from 'lucide-react'
+import portfolioData from '@/data/portfolio.json'
+
+const engagements = [
+  {
+    icon: Mic,
+    title: 'Speaking',
+    description:
+      'Conference talks, podcasts, and workshops on fuzzing, Ethereum protocol security, and post-quantum cryptography testing.',
+  },
+  {
+    icon: FlaskConical,
+    title: 'Research collaboration',
+    description:
+      'Joint work on differential fuzzing, client testing, side-channel analysis, and AI-assisted vulnerability research.',
+  },
+  {
+    icon: ShieldCheck,
+    title: 'Security reviews',
+    description:
+      'Independent reviews of protocol implementations, cryptographic code, and fuzzing setups — subject to availability.',
+  },
+]
+
+export default function Contact() {
+  const { email, social } = portfolioData.personal
+
+  return (
+    <section id="contact" className="border-t border-line py-24 md:py-28">
+      <div className="container-max section-padding">
+        <div className="mb-16">
+          <p className="eyebrow mb-4">07 — Contact</p>
+          <h2 className="section-title">Work with me</h2>
+          <p className="mt-4 max-w-2xl text-lg text-muted">
+            I&apos;m open to a few kinds of engagements. A short email that says what you&apos;re
+            working on and what you need gets the fastest reply.
+          </p>
+        </div>
+
+        <div className="grid grid-cols-1 gap-8 md:grid-cols-3">
+          {engagements.map((item) => (
+            <div key={item.title} className="border-t border-line pt-6">
+              <item.icon size={20} className="mb-4 text-accent" aria-hidden="true" />
+              <h3 className="mb-2 text-lg font-semibold text-fg">{item.title}</h3>
+              <p className="text-sm leading-relaxed text-muted">{item.description}</p>
+            </div>
+          ))}
+        </div>
+
+        <div className="mt-14 flex flex-col items-start gap-4 sm:flex-row sm:items-center">
+          <a
+            href={`mailto:${email}`}
+            className="btn-primary inline-flex items-center gap-2 px-6 py-3 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+          >
+            <Mail size={16} />
+            <span>{email}</span>
+          </a>
+          <a
+            href={`https://keybase.io/${social.keybase}/pgp_keys.asc`}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="btn-ghost inline-flex items-center gap-2 px-6 py-3 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+          >
+            <Key size={16} />
+            <span>PGP key for sensitive reports</span>
+          </a>
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -91,6 +91,11 @@ export default function Footer() {
                   CV (PDF)
                 </a>
               </li>
+              <li>
+                <a href="#contact" className="text-muted transition-colors hover:text-fg">
+                  Work with me
+                </a>
+              </li>
             </ul>
           </div>
 
@@ -147,6 +152,14 @@ export default function Footer() {
                   Blog
                 </Link>
               </li>
+              <li>
+                <a
+                  href="/feed.xml"
+                  className="inline-flex items-center space-x-1 text-muted transition-colors hover:text-fg"
+                >
+                  <span>RSS Feed</span>
+                </a>
+              </li>
             </ul>
           </div>
         </div>
@@ -162,13 +175,13 @@ export default function Footer() {
                 href="/privacy"
                 className="font-mono text-xs text-faint transition-colors hover:text-fg"
               >
-                Privacy Policy
+                Privacy
               </Link>
               <Link
                 href="/terms"
                 className="font-mono text-xs text-faint transition-colors hover:text-fg"
               >
-                Terms of Service
+                Disclaimer
               </Link>
               <p className="font-mono text-xs text-faint">Built with Next.js &amp; Tailwind CSS</p>
             </div>

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -20,6 +20,7 @@ const navigation: NavItem[] = [
   { name: 'Talks', href: '#talks', id: 'talks' },
   { name: 'Pubs', href: '#publications', id: 'publications' },
   { name: 'Blog', href: '/blog' },
+  { name: 'Contact', href: '#contact', id: 'contact' },
 ]
 
 export default function Header() {
@@ -30,7 +31,7 @@ export default function Header() {
   useEffect(() => {
     const handleScroll = () => {
       setIsScrolled(window.scrollY > 10)
-      const sections = ['home', 'about', 'projects', 'findings', 'talks', 'publications']
+      const sections = ['home', 'about', 'projects', 'findings', 'talks', 'publications', 'contact']
       const scrollPosition = window.scrollY + 100
       for (const section of sections) {
         const element = document.getElementById(section)

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -57,16 +57,18 @@ export default function Header() {
     }`
   }
 
-  const renderLink = (item: NavItem, onClick?: () => void) =>
-    item.id ? (
-      <a key={item.name} href={item.href} onClick={onClick} className={linkClass(item)}>
+  const renderLink = (item: NavItem, onClick?: () => void, block = false) => {
+    const className = block ? `block ${linkClass(item)}` : linkClass(item)
+    return item.id ? (
+      <a key={item.name} href={item.href} onClick={onClick} className={className}>
         {item.name}
       </a>
     ) : (
-      <Link key={item.name} href={item.href} onClick={onClick} className={linkClass(item)}>
+      <Link key={item.name} href={item.href} onClick={onClick} className={className}>
         {item.name}
       </Link>
     )
+  }
 
   return (
     <header
@@ -138,7 +140,7 @@ export default function Header() {
         {isMenuOpen && (
           <div className="md:hidden">
             <div className="mt-2 space-y-1 rounded-lg border border-line bg-surface px-2 pb-3 pt-2">
-              {navigation.map((item) => renderLink(item, closeMobile))}
+              {navigation.map((item) => renderLink(item, closeMobile, true))}
               <div className="flex items-center space-x-4 px-1 py-2">
                 <a
                   href="https://github.com/bshastry"

--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -34,7 +34,9 @@ export default function Hero({ latestPost }: { latestPost: LatestPost | null }) 
 
   return (
     <section id="home" className="flex min-h-screen items-center justify-center bg-bg pt-16">
-      <div className="container-max section-padding">
+      {/* min-w-0 lets the latest-post pill's nowrap title truncate instead of
+          inflating this flex item's min-content width past the viewport. */}
+      <div className="container-max section-padding w-full min-w-0">
         <div className="animate-fade-in text-center">
           {/* Main heading */}
           <h1 className="text-6xl font-semibold tracking-tight text-fg md:text-8xl">

--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -2,7 +2,6 @@
 
 import Link from 'next/link'
 import { ArrowDown, FileDown, Sparkles } from 'lucide-react'
-import portfolioData from '@/data/portfolio.json'
 
 const stats = [
   { value: '10+', label: 'years' },
@@ -26,8 +25,6 @@ function formatDate(date: string): string {
 }
 
 export default function Hero({ latestPost }: { latestPost: LatestPost | null }) {
-  const { email } = portfolioData.personal
-
   const scrollToAbout = () => {
     const element = document.getElementById('about')
     if (element) {
@@ -96,10 +93,10 @@ export default function Hero({ latestPost }: { latestPost: LatestPost | null }) 
               <span>Download CV</span>
             </a>
             <a
-              href={`mailto:${email}`}
+              href="#contact"
               className="btn-ghost px-6 py-3 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
             >
-              Email me
+              Work with me
             </a>
           </div>
 

--- a/components/Talks.tsx
+++ b/components/Talks.tsx
@@ -2,7 +2,7 @@ import { FileText, Video, MapPin, Calendar } from 'lucide-react'
 import portfolioData from '@/data/portfolio.json'
 
 export default function Talks() {
-  const { talks } = portfolioData
+  const talks = [...portfolioData.talks].sort((a, b) => b.year - a.year)
 
   return (
     <section id="talks" className="py-24 md:py-28">

--- a/data/portfolio.json
+++ b/data/portfolio.json
@@ -87,7 +87,11 @@
         "Earlier: EIP-7702 differential fuzzers across geth, Nethermind, and Besu; PrecompileFuzzer for the Prague hard fork; EthFuzzNet network-resilience testing"
       ],
       "links": [
-        { "label": "goevmlab", "url": "https://github.com/holiman/goevmlab", "type": "github" },
+        {
+          "label": "goevmlab",
+          "url": "https://github.com/holiman/goevmlab",
+          "type": "github"
+        },
         {
           "label": "execution-specs",
           "url": "https://github.com/ethereum/execution-specs",
@@ -107,7 +111,11 @@
         "Built internal tooling that manages the submission-to-triage workflow end to end"
       ],
       "links": [
-        { "label": "Ethereum Bug Bounty", "url": "https://bounty.ethereum.org", "type": "external" }
+        {
+          "label": "Ethereum Bug Bounty",
+          "url": "https://bounty.ethereum.org",
+          "type": "external"
+        }
       ]
     },
     {
@@ -182,7 +190,11 @@
         "Discovered and reported numerous compiler correctness bugs through structure-aware fuzzing"
       ],
       "links": [
-        { "label": "Solidity", "url": "https://github.com/ethereum/solidity", "type": "github" }
+        {
+          "label": "Solidity",
+          "url": "https://github.com/ethereum/solidity",
+          "type": "github"
+        }
       ]
     },
     {
@@ -199,7 +211,11 @@
         "Security research on Prysm (Ethereum consensus client)"
       ],
       "links": [
-        { "label": "rust-libp2p", "url": "https://github.com/libp2p/rust-libp2p", "type": "github" }
+        {
+          "label": "rust-libp2p",
+          "url": "https://github.com/libp2p/rust-libp2p",
+          "type": "github"
+        }
       ]
     },
     {
@@ -214,8 +230,16 @@
         "Developed custom protocol-buffer based mutation strategies for structure-aware fuzzing"
       ],
       "links": [
-        { "label": "orthrus", "url": "https://github.com/bshastry/orthrus", "type": "github" },
-        { "label": "oss-fuzz", "url": "https://github.com/google/oss-fuzz", "type": "github" }
+        {
+          "label": "orthrus",
+          "url": "https://github.com/bshastry/orthrus",
+          "type": "github"
+        },
+        {
+          "label": "oss-fuzz",
+          "url": "https://github.com/google/oss-fuzz",
+          "type": "github"
+        }
       ]
     },
     {
@@ -231,7 +255,11 @@
         "Discovered and reported Boost Filesystem crash bugs"
       ],
       "links": [
-        { "label": "Open vSwitch", "url": "https://github.com/openvswitch/ovs", "type": "github" }
+        {
+          "label": "Open vSwitch",
+          "url": "https://github.com/openvswitch/ovs",
+          "type": "github"
+        }
       ]
     },
     {
@@ -409,56 +437,56 @@
           "authors": "V. Ulitzsch, D. Maier, B. Shastry",
           "venue": "Black Hat 2018",
           "award": null,
-          "url": null
+          "url": "https://i.blackhat.com/us-18/Thu-August-9/us-18-Ulitzsch-Follow-The-White-Rabbit-Simplifying-Fuzz-Testing-Using-FuzzExMachina.pdf"
         },
         {
           "title": "Taking Control of SDN-based Cloud Systems via the Data Plane",
           "authors": "K. Thimmaraju, B. Shastry, T. Fiebig, F. Hetzelt, J.P. Seifert, A. Feldmann, S. Schmid",
           "venue": "Symposium on SDN Research 2018",
           "award": "Best Paper Award",
-          "url": null
+          "url": "https://doi.org/10.1145/3185467.3185468"
         },
         {
           "title": "The vAMP Attack: Taking Control of Cloud Systems via the Unified Packet Parser",
           "authors": "K. Thimmaraju, B. Shastry, T. Fiebig, F. Hetzelt, J.P. Seifert, A. Feldmann, S. Schmid",
           "venue": "Cloud Computing Security Workshop 2017",
           "award": null,
-          "url": null
+          "url": "https://doi.org/10.1145/3140649.3140651"
         },
         {
           "title": "Static Program Analysis as a Fuzzing Aid",
           "authors": "B. Shastry, M. Leutner, T. Fiebig, K. Thimmaraju, F. Yamaguchi, K. Rieck, S. Schmid, J.P. Seifert, A. Feldmann",
           "venue": "RAID 2017",
           "award": null,
-          "url": null
+          "url": "https://doi.org/10.1007/978-3-319-66332-6_2"
         },
         {
           "title": "Static exploration of taint-style vulnerabilities found by fuzzing",
           "authors": "B. Shastry, F. Maggi, F. Yamaguchi, K. Rieck, J.P. Seifert",
           "venue": "USENIX WOOT 2017",
           "award": null,
-          "url": null
+          "url": "https://www.usenix.org/conference/woot17/workshop-program/presentation/shastry"
         },
         {
           "title": "Leveraging flawed tutorials for seeding large-scale web vulnerability discovery",
           "authors": "T. Unruh, B. Shastry, M. Skoruppa, F. Maggi, K. Rieck, J.P. Seifert, F. Yamaguchi",
           "venue": "USENIX WOOT 2017",
           "award": null,
-          "url": null
+          "url": "https://www.usenix.org/conference/woot17/workshop-program/presentation/unruh"
         },
         {
           "title": "Towards Vulnerability Discovery Using Staged Program Analysis",
           "authors": "B. Shastry, F. Yamaguchi, K. Rieck, J.P. Seifert",
           "venue": "DIMVA 2016",
           "award": null,
-          "url": null
+          "url": "https://doi.org/10.1007/978-3-319-40667-1_5"
         },
         {
           "title": "A First Look at Firefox OS Security",
           "authors": "D. Defreez, B. Shastry, H. Chen, J.P. Seifert",
           "venue": "MoST 2014",
           "award": null,
-          "url": null
+          "url": "https://arxiv.org/abs/1410.7754"
         }
       ]
     },
@@ -470,14 +498,14 @@
           "authors": "S. Bugiel, L. Davi, A. Dmitrienko, T. Fischer, A.R. Sadeghi, B. Shastry",
           "venue": "NDSS 2012",
           "award": null,
-          "url": null
+          "url": "https://www.ndss-symposium.org/ndss2012/ndss-2012-programme/towards-taming-privilege-escalation-attacks-android/"
         },
         {
           "title": "Practical and lightweight domain isolation on android",
           "authors": "S. Bugiel, L. Davi, A. Dmitrienko, S. Heuser, A.R. Sadeghi, B. Shastry",
           "venue": "ACM SPSM 2011",
           "award": null,
-          "url": null
+          "url": "https://doi.org/10.1145/2046614.2046624"
         }
       ]
     }

--- a/lib/blog.ts
+++ b/lib/blog.ts
@@ -40,8 +40,14 @@ export interface BlogPostMeta {
   series?: SeriesInfo
 }
 
+export interface PostHeading {
+  id: string
+  text: string
+}
+
 export interface BlogPost extends BlogPostMeta {
   contentHtml: string
+  headings: PostHeading[]
 }
 
 interface PostFrontmatter {
@@ -143,6 +149,28 @@ export function getSeriesParts(seriesId: string, currentSlug?: string): SeriesPa
   return parts.length > 1 ? parts : []
 }
 
+/**
+ * Top-level (h2) headings extracted from the rendered HTML, used for the
+ * table of contents. Ids come from rehype-slug, so anchors always match.
+ */
+function extractHeadings(contentHtml: string): PostHeading[] {
+  const headings: PostHeading[] = []
+  const pattern = /<h2 id="([^"]+)"[^>]*>([\s\S]*?)<\/h2>/g
+  let match: RegExpExecArray | null
+  while ((match = pattern.exec(contentHtml)) !== null) {
+    const text = match[2]
+      .replace(/<[^>]+>/g, '')
+      .replace(/&amp;/g, '&')
+      .replace(/&lt;/g, '<')
+      .replace(/&gt;/g, '>')
+      .replace(/&quot;/g, '"')
+      .replace(/&#x27;|&#39;/g, "'")
+      .trim()
+    if (text) headings.push({ id: match[1], text })
+  }
+  return headings
+}
+
 export async function getPostBySlug(slug: string): Promise<BlogPost | null> {
   const parsed = readPostFile(slug)
   if (!parsed) return null
@@ -161,6 +189,8 @@ export async function getPostBySlug(slug: string): Promise<BlogPost | null> {
     .use(rehypeStringify)
     .process(body)
 
+  const contentHtml = String(processed)
+
   return {
     slug,
     title: frontmatter.title,
@@ -169,6 +199,7 @@ export async function getPostBySlug(slug: string): Promise<BlogPost | null> {
     tags: frontmatter.tags ?? [],
     readTime: computeReadTime(body),
     series: parseSeries(frontmatter, slug),
-    contentHtml: String(processed),
+    contentHtml,
+    headings: extractHeadings(contentHtml),
   }
 }


### PR DESCRIPTION
## Summary

Addresses the site review's critical and high-priority items: conversion, per-page SEO, and trust polish.

### Blog SEO (critical)
- Per-post metadata: unique title/description, canonical URL, `og:type=article` with published time and tags, Twitter card
- BlogPosting JSON-LD on every post; Person JSON-LD on the homepage
- Per-post OpenGraph share images (generated at build time)
- Blog index gets its own metadata and canonical
- Sitemap URLs now match the served trailing-slash URLs and carry post `lastmod` dates

### Legal copy (critical)
- Privacy policy rewritten as a short, factually exact notice: no contact form claims, fixed last-updated date (was rendering the current date on every visit), GitHub Pages IP-logging disclosure, localStorage theme note, email contact
- Terms replaced with a concise disclaimer: personal views, responsible use of security research, no warranty

### Conversion (high)
- New "Work with me" section: speaking, research collaboration, security reviews — with email CTA and PGP key link; wired into header nav, hero CTA, and footer

### Blog distribution (high)
- RSS feed at `/feed.xml` (all 26 posts) with discovery links in document head, blog index, and footer
- Semantic `<time>` elements on all dates
- "On this page" table of contents for posts with 3+ sections

### Evidence (high)
- Verified canonical links (DOI / USENIX / NDSS / arXiv / Black Hat) added for all ten previously unlinked publications

### Accessibility & polish (medium)
- Skip-to-content link; header/footer moved outside `<main>`; main landmarks on all pages
- Talks sorted newest first
- Fixed a pre-existing mobile bug: hero section forced ~110px of horizontal scroll at phone widths (flex min-content inflation from the latest-post pill's nowrap title); mobile menu links now stack vertically instead of overflowing off-screen

## Testing
- `npm run check` (typecheck, ESLint, Prettier) passes; `next build` static export succeeds (64 pages)
- Verified generated HTML: canonicals, og tags, JSON-LD, valid RSS XML, sitemap entries
- Playwright render tests at 375×812 and 1440×900 across home, blog index, post, privacy, terms: no console errors, no horizontal overflow; mobile menu and contact section interactions verified with screenshots

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ED3zmuCj4fXiJ3fgtHeC3Y

---
_Generated by [Claude Code](https://claude.ai/code/session_01ED3zmuCj4fXiJ3fgtHeC3Y)_