### PR TITLE
Raise portfolio design quality and accessibility

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -2,28 +2,28 @@
 @tailwind components;
 @tailwind utilities;
 
-@import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap');
-
 @layer base {
   /* Semantic theme tokens as RGB triplets. Light values on :root,
      dark values under html.dark. Dark is the default (see layout.tsx). */
   :root {
+    color-scheme: light;
     --bg: 250 250 250;
     --surface: 255 255 255;
     --fg: 17 17 17;
     --muted: 92 92 92;
-    --faint: 138 138 138;
+    --faint: 110 110 110;
     --line: 230 230 230;
     --line-strong: 212 212 212;
     --accent: 37 99 235;
   }
 
   html.dark {
+    color-scheme: dark;
     --bg: 10 10 10;
     --surface: 20 20 20;
     --fg: 237 237 237;
     --muted: 138 138 138;
-    --faint: 90 90 90;
+    --faint: 128 128 128;
     --line: 31 31 31;
     --line-strong: 46 46 46;
     --accent: 110 168 254;
@@ -31,10 +31,16 @@
 
   html {
     scroll-behavior: smooth;
+    scroll-padding-top: 5rem;
   }
 
   body {
     @apply bg-bg text-fg antialiased;
+    min-width: 320px;
+  }
+
+  section[id] {
+    scroll-margin-top: 4rem;
   }
 
   ::selection {
@@ -65,7 +71,7 @@
   }
 
   .link-accent {
-    @apply text-accent transition-opacity hover:opacity-80;
+    @apply rounded-sm text-accent transition-opacity hover:opacity-80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-bg;
   }
 
   .panel {
@@ -73,11 +79,11 @@
   }
 
   .btn-primary {
-    @apply rounded-md bg-accent px-4 py-2 font-medium text-bg transition-opacity duration-200 hover:opacity-90;
+    @apply inline-flex min-h-11 items-center justify-center rounded-md bg-accent px-4 py-2 font-medium text-bg transition-opacity duration-200 hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-bg;
   }
 
   .btn-ghost {
-    @apply rounded-md border border-line px-4 py-2 font-medium text-fg transition-colors duration-200 hover:border-line-strong;
+    @apply inline-flex min-h-11 items-center justify-center rounded-md border border-line px-4 py-2 font-medium text-fg transition-colors duration-200 hover:border-line-strong hover:bg-surface focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-bg;
   }
 
   /* Legacy aliases retained so any unmigrated references stay coherent. */
@@ -86,11 +92,62 @@
   }
 
   .btn-secondary {
-    @apply rounded-md border border-line px-4 py-2 font-medium text-fg transition-colors duration-200 hover:border-line-strong;
+    @apply inline-flex min-h-11 items-center justify-center rounded-md border border-line px-4 py-2 font-medium text-fg transition-colors duration-200 hover:border-line-strong hover:bg-surface focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-bg;
   }
 
   .text-gradient {
     @apply text-accent;
+  }
+}
+
+/* A restrained systems-diagram motif gives the hero a visual identity without
+   shipping decorative image assets. */
+.hero-grid {
+  background-image:
+    radial-gradient(circle at 78% 30%, rgb(var(--accent) / 0.13), transparent 26rem),
+    linear-gradient(rgb(var(--line) / 0.42) 1px, transparent 1px),
+    linear-gradient(90deg, rgb(var(--line) / 0.42) 1px, transparent 1px);
+  background-size:
+    auto,
+    48px 48px,
+    48px 48px;
+  -webkit-mask-image: linear-gradient(to bottom, black 0%, rgb(0 0 0 / 0.72) 68%, transparent 100%);
+  mask-image: linear-gradient(to bottom, black 0%, rgb(0 0 0 / 0.72) 68%, transparent 100%);
+}
+
+.signal-panel::before {
+  position: absolute;
+  inset: 1.25rem auto 1.25rem 0;
+  width: 2px;
+  border-radius: 999px;
+  background: linear-gradient(to bottom, transparent, rgb(var(--accent)), transparent);
+  content: '';
+}
+
+@media (prefers-reduced-motion: reduce) {
+  html {
+    scroll-behavior: auto;
+  }
+
+  *,
+  *::before,
+  *::after {
+    scroll-behavior: auto !important;
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
+}
+
+@media (prefers-contrast: more) {
+  :root {
+    --line: 190 190 190;
+    --line-strong: 150 150 150;
+  }
+
+  html.dark {
+    --line: 86 86 86;
+    --line-strong: 120 120 120;
   }
 }
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -31,7 +31,6 @@
 
   html {
     scroll-behavior: smooth;
-    scroll-padding-top: 5rem;
   }
 
   body {
@@ -39,8 +38,11 @@
     min-width: 320px;
   }
 
+  /* Single anchor-offset mechanism: 4rem fixed header + breathing room.
+     Deliberately not scroll-padding on html — that would also offset heading
+     anchors on blog/research pages, which have no fixed header. */
   section[id] {
-    scroll-margin-top: 4rem;
+    scroll-margin-top: 5rem;
   }
 
   ::selection {
@@ -55,6 +57,12 @@
 
   .container-max {
     @apply mx-auto max-w-6xl;
+  }
+
+  /* Shared keyboard-focus treatment; keep JSX call sites on this class so the
+     ring can be retuned in one place. */
+  .focus-ring {
+    @apply focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-bg;
   }
 
   /* Minimal editorial primitives */
@@ -91,10 +99,6 @@
     @apply rounded-lg border border-line bg-surface;
   }
 
-  .btn-secondary {
-    @apply inline-flex min-h-11 items-center justify-center rounded-md border border-line px-4 py-2 font-medium text-fg transition-colors duration-200 hover:border-line-strong hover:bg-surface focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-bg;
-  }
-
   .text-gradient {
     @apply text-accent;
   }
@@ -125,10 +129,6 @@
 }
 
 @media (prefers-reduced-motion: reduce) {
-  html {
-    scroll-behavior: auto;
-  }
-
   *,
   *::before,
   *::after {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,7 +3,9 @@ import { Inter } from 'next/font/google'
 import { pageAlternates } from '@/lib/seo'
 import './globals.css'
 
-const inter = Inter({ subsets: ['latin'] })
+// The CSS variable keeps Tailwind's font-sans token pointing at the self-hosted
+// next/font family; nothing else loads a face literally named "Inter".
+const inter = Inter({ subsets: ['latin'], variable: '--font-inter' })
 
 export const metadata: Metadata = {
   metadataBase: new URL('https://bshastry.github.io'),
@@ -58,7 +60,7 @@ const themeScript = `
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
-    <html lang="en" className="dark scroll-smooth" suppressHydrationWarning>
+    <html lang="en" className={`dark scroll-smooth ${inter.variable}`} suppressHydrationWarning>
       <head>
         <script dangerouslySetInnerHTML={{ __html: themeScript }} />
       </head>

--- a/components/About.tsx
+++ b/components/About.tsx
@@ -38,10 +38,10 @@ export default function About() {
         <div className="mb-16 grid grid-cols-1 gap-12 lg:grid-cols-2 lg:gap-16">
           {/* Prose */}
           <div>
-            <h3 className="mb-4 text-2xl font-semibold text-fg">
+            <h3 className="mb-5 text-2xl font-semibold text-fg">
               Turning disagreement into evidence
             </h3>
-            <p className="mb-4 leading-relaxed text-muted">
+            <p className="mb-5 text-lg leading-relaxed text-fg">
               My working thesis: in a system with more than one implementation there is no ground
               truth — only witnesses that can disagree. I make them disagree under controlled
               conditions. I build coverage-guided differential fuzzers that run Ethereum&apos;s
@@ -66,7 +66,7 @@ export default function About() {
           </div>
 
           {/* Expertise + CV */}
-          <div className="space-y-8">
+          <div className="h-fit space-y-8 rounded-xl border border-line bg-surface/50 p-6 sm:p-8">
             <div>
               <h4 className="mb-4 text-lg font-semibold text-fg">Core Expertise</h4>
               <ul className="grid grid-cols-1 gap-x-8 gap-y-2 sm:grid-cols-2">

--- a/components/CaseStudies.tsx
+++ b/components/CaseStudies.tsx
@@ -5,7 +5,7 @@ export default function CaseStudies() {
   const { caseStudies } = portfolioData
 
   return (
-    <section id="case-studies" className="border-t border-line py-24 md:py-28">
+    <section id="case-studies" className="border-t border-line bg-surface/30 py-24 md:py-28">
       <div className="container-max section-padding">
         <div className="mb-16">
           <p className="eyebrow mb-4">02 — Case Studies</p>
@@ -17,14 +17,23 @@ export default function CaseStudies() {
           </p>
         </div>
 
-        <div className="space-y-12">
-          {caseStudies.map((cs) => (
-            <article key={cs.id} className="border-t border-line pt-8">
-              <p className="eyebrow mb-3 text-accent">{cs.eyebrow}</p>
+        <div className="space-y-6">
+          {caseStudies.map((cs, index) => (
+            <article
+              key={cs.id}
+              className="relative overflow-hidden rounded-xl border border-line bg-bg/80 p-6 md:p-8"
+            >
+              <span aria-hidden="true" className="absolute bottom-8 left-0 top-8 w-px bg-accent" />
+              <div className="mb-3 flex items-center gap-3">
+                <span className="font-mono text-xs text-faint">
+                  {String(index + 1).padStart(2, '0')}
+                </span>
+                <p className="eyebrow text-accent">{cs.eyebrow}</p>
+              </div>
               <h3 className="mb-6 max-w-3xl text-balance text-2xl font-semibold text-fg">
                 {cs.title}
               </h3>
-              <dl className="grid grid-cols-1 gap-x-10 gap-y-5 md:grid-cols-3">
+              <dl className="grid grid-cols-1 gap-x-10 gap-y-5 border-t border-line pt-6 md:grid-cols-3">
                 <div>
                   <dt className="eyebrow mb-2">Stakes</dt>
                   <dd className="text-sm leading-relaxed text-muted">{cs.stakes}</dd>
@@ -38,7 +47,7 @@ export default function CaseStudies() {
                   <dd className="text-sm leading-relaxed text-muted">{cs.result}</dd>
                 </div>
               </dl>
-              <div className="mt-6 flex flex-wrap items-center gap-x-6 gap-y-3">
+              <div className="mt-7 flex flex-wrap items-center gap-x-6 gap-y-3 border-t border-line pt-5">
                 <span className="font-mono text-xs text-faint">{cs.demonstrates}</span>
                 <span className="flex flex-wrap items-center gap-4">
                   {cs.evidence.map((link) => (

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -42,10 +42,19 @@ export default function Header() {
   const [isMenuOpen, setIsMenuOpen] = useState(false)
   const [isScrolled, setIsScrolled] = useState(false)
   const [activeSection, setActiveSection] = useState<string>('home')
+  const [scrollProgress, setScrollProgress] = useState(0)
 
   useEffect(() => {
-    const handleScroll = () => {
+    let frame: number | null = null
+
+    const updateScrollState = () => {
       setIsScrolled(window.scrollY > 10)
+
+      const scrollableHeight = document.documentElement.scrollHeight - window.innerHeight
+      setScrollProgress(
+        scrollableHeight > 0 ? Math.min(1, Math.max(0, window.scrollY / scrollableHeight)) : 0,
+      )
+
       const scrollPosition = window.scrollY + 100
       for (const section of sectionIds) {
         const element = document.getElementById(section)
@@ -56,25 +65,54 @@ export default function Header() {
           break
         }
       }
+
+      frame = null
     }
+
+    const handleScroll = () => {
+      if (frame === null) frame = window.requestAnimationFrame(updateScrollState)
+    }
+
     window.addEventListener('scroll', handleScroll, { passive: true })
-    handleScroll()
-    return () => window.removeEventListener('scroll', handleScroll)
+    updateScrollState()
+
+    return () => {
+      window.removeEventListener('scroll', handleScroll)
+      if (frame !== null) window.cancelAnimationFrame(frame)
+    }
   }, [])
+
+  useEffect(() => {
+    if (!isMenuOpen) return
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') setIsMenuOpen(false)
+    }
+
+    document.addEventListener('keydown', handleKeyDown)
+    return () => document.removeEventListener('keydown', handleKeyDown)
+  }, [isMenuOpen])
 
   const closeMobile = () => setIsMenuOpen(false)
 
-  const linkClass = (item: NavItem) => {
+  const linkClass = (item: NavItem, block = false) => {
     const isActive = item.id && activeSection === item.id
-    return `px-1 py-2 text-sm font-medium border-b-2 transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent ${
+    return `${block ? 'flex w-full' : 'inline-flex'} min-h-11 items-center border-b-2 px-1 py-2 text-sm font-medium transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-bg ${
       isActive ? 'text-fg border-accent' : 'text-muted border-transparent hover:text-fg'
     }`
   }
 
   const renderLink = (item: NavItem, onClick?: () => void, block = false) => {
-    const className = block ? `block ${linkClass(item)}` : linkClass(item)
+    const className = linkClass(item, block)
+    const isActive = Boolean(item.id && activeSection === item.id)
     return item.id ? (
-      <a key={item.name} href={item.href} onClick={onClick} className={className}>
+      <a
+        key={item.name}
+        href={item.href}
+        onClick={onClick}
+        className={className}
+        aria-current={isActive ? 'location' : undefined}
+      >
         {item.name}
       </a>
     ) : (
@@ -87,33 +125,33 @@ export default function Header() {
   return (
     <header
       className={`fixed left-0 right-0 top-0 z-50 transition-all duration-300 ${
-        isScrolled ? 'border-b border-line bg-bg/90 backdrop-blur' : 'bg-transparent'
+        isScrolled || isMenuOpen ? 'border-b border-line bg-bg/90 backdrop-blur' : 'bg-transparent'
       }`}
     >
-      <nav className="container-max section-padding">
+      <nav aria-label="Primary navigation" className="container-max section-padding">
         <div className="flex h-16 items-center justify-between">
           <div className="flex-shrink-0">
             <a
               href="#home"
-              className="rounded-sm text-xl font-semibold tracking-tight text-fg transition-opacity hover:opacity-80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+              className="inline-flex min-h-11 items-center rounded-sm text-lg font-semibold tracking-tight text-fg transition-opacity hover:opacity-80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-bg xl:text-xl"
             >
               Bhargava Shastry
             </a>
           </div>
 
-          <div className="hidden md:block">
-            <div className="ml-10 flex items-baseline space-x-6">
+          <div className="hidden lg:block">
+            <div className="ml-6 flex items-baseline space-x-4 xl:ml-10 xl:space-x-6">
               {navigation.map((item) => renderLink(item))}
             </div>
           </div>
 
-          <div className="hidden items-center space-x-4 md:flex">
+          <div className="hidden items-center space-x-1 lg:flex xl:space-x-2">
             <a
               href="https://github.com/bshastry"
               target="_blank"
               rel="noopener noreferrer"
               aria-label="GitHub profile"
-              className="rounded-sm text-muted transition-colors hover:text-fg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+              className="inline-flex h-10 w-10 items-center justify-center rounded-md text-muted transition-colors hover:text-fg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-bg"
             >
               <Github size={20} />
             </a>
@@ -122,7 +160,7 @@ export default function Header() {
               target="_blank"
               rel="noopener noreferrer"
               aria-label="Twitter profile"
-              className="rounded-sm text-muted transition-colors hover:text-fg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+              className="inline-flex h-10 w-10 items-center justify-center rounded-md text-muted transition-colors hover:text-fg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-bg"
             >
               <Twitter size={20} />
             </a>
@@ -131,20 +169,21 @@ export default function Header() {
               target="_blank"
               rel="noopener noreferrer"
               aria-label="LinkedIn profile"
-              className="rounded-sm text-muted transition-colors hover:text-fg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+              className="inline-flex h-10 w-10 items-center justify-center rounded-md text-muted transition-colors hover:text-fg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-bg"
             >
               <Linkedin size={20} />
             </a>
             <ThemeToggle />
           </div>
 
-          <div className="md:hidden">
+          <div className="lg:hidden">
             <button
               type="button"
               onClick={() => setIsMenuOpen(!isMenuOpen)}
               aria-label={isMenuOpen ? 'Close navigation menu' : 'Open navigation menu'}
               aria-expanded={isMenuOpen}
-              className="rounded-sm text-muted transition-colors hover:text-fg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+              aria-controls="mobile-navigation"
+              className="inline-flex h-11 w-11 items-center justify-center rounded-md text-muted transition-colors hover:text-fg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-bg"
             >
               {isMenuOpen ? <X size={24} /> : <Menu size={24} />}
             </button>
@@ -152,8 +191,8 @@ export default function Header() {
         </div>
 
         {isMenuOpen && (
-          <div className="md:hidden">
-            <div className="mt-2 space-y-1 rounded-lg border border-line bg-surface px-2 pb-3 pt-2">
+          <div id="mobile-navigation" className="lg:hidden">
+            <div className="mb-3 mt-2 space-y-1 rounded-xl border border-line bg-surface px-3 py-3 shadow-xl shadow-black/10">
               {navigation.map((item) => renderLink(item, closeMobile, true))}
               <div className="flex items-center space-x-4 px-1 py-2">
                 <a
@@ -161,7 +200,7 @@ export default function Header() {
                   target="_blank"
                   rel="noopener noreferrer"
                   aria-label="GitHub profile"
-                  className="rounded-sm text-muted transition-colors hover:text-fg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+                  className="inline-flex h-11 w-11 items-center justify-center rounded-md text-muted transition-colors hover:text-fg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
                 >
                   <Github size={20} />
                 </a>
@@ -170,7 +209,7 @@ export default function Header() {
                   target="_blank"
                   rel="noopener noreferrer"
                   aria-label="Twitter profile"
-                  className="rounded-sm text-muted transition-colors hover:text-fg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+                  className="inline-flex h-11 w-11 items-center justify-center rounded-md text-muted transition-colors hover:text-fg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
                 >
                   <Twitter size={20} />
                 </a>
@@ -179,7 +218,7 @@ export default function Header() {
                   target="_blank"
                   rel="noopener noreferrer"
                   aria-label="LinkedIn profile"
-                  className="rounded-sm text-muted transition-colors hover:text-fg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+                  className="inline-flex h-11 w-11 items-center justify-center rounded-md text-muted transition-colors hover:text-fg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
                 >
                   <Linkedin size={20} />
                 </a>
@@ -189,6 +228,11 @@ export default function Header() {
           </div>
         )}
       </nav>
+      <span
+        aria-hidden="true"
+        className="absolute bottom-0 left-0 h-px w-full origin-left bg-accent transition-transform duration-150"
+        style={{ transform: `scaleX(${scrollProgress})` }}
+      />
     </header>
   )
 }

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useRef } from 'react'
 import Link from 'next/link'
 import { Menu, X, Github, Twitter, Linkedin } from 'lucide-react'
 import ThemeToggle from '@/components/ThemeToggle'
@@ -23,6 +23,17 @@ const navigation: NavItem[] = [
   { name: 'Work', href: '#contact', id: 'contact' },
 ]
 
+// Hardcoded rather than imported from portfolio.json so this client component
+// doesn't pull the whole data file into the bundle for three URLs.
+const socialLinks = [
+  { label: 'GitHub profile', href: 'https://github.com/bshastry', Icon: Github },
+  { label: 'Twitter profile', href: 'https://twitter.com/ibags', Icon: Twitter },
+  { label: 'LinkedIn profile', href: 'https://linkedin.com/in/bshastry', Icon: Linkedin },
+]
+
+const iconLinkClass = (size: string) =>
+  `focus-ring inline-flex ${size} items-center justify-center rounded-md text-muted transition-colors hover:text-fg`
+
 // Scroll-spy tracks every homepage section, including ones without a nav
 // item (home, writing) — otherwise the previous section's link would stay
 // highlighted while the user scrolls through them.
@@ -42,7 +53,8 @@ export default function Header() {
   const [isMenuOpen, setIsMenuOpen] = useState(false)
   const [isScrolled, setIsScrolled] = useState(false)
   const [activeSection, setActiveSection] = useState<string>('home')
-  const [scrollProgress, setScrollProgress] = useState(0)
+  const progressRef = useRef<HTMLSpanElement>(null)
+  const menuButtonRef = useRef<HTMLButtonElement>(null)
 
   useEffect(() => {
     let frame: number | null = null
@@ -50,10 +62,12 @@ export default function Header() {
     const updateScrollState = () => {
       setIsScrolled(window.scrollY > 10)
 
+      // The progress bar is driven through a ref, not state: a per-frame
+      // setState would re-render the whole header on every scrolled frame.
       const scrollableHeight = document.documentElement.scrollHeight - window.innerHeight
-      setScrollProgress(
-        scrollableHeight > 0 ? Math.min(1, Math.max(0, window.scrollY / scrollableHeight)) : 0,
-      )
+      const progress =
+        scrollableHeight > 0 ? Math.min(1, Math.max(0, window.scrollY / scrollableHeight)) : 0
+      if (progressRef.current) progressRef.current.style.transform = `scaleX(${progress})`
 
       const scrollPosition = window.scrollY + 100
       for (const section of sectionIds) {
@@ -69,15 +83,18 @@ export default function Header() {
       frame = null
     }
 
-    const handleScroll = () => {
+    const requestUpdate = () => {
       if (frame === null) frame = window.requestAnimationFrame(updateScrollState)
     }
 
-    window.addEventListener('scroll', handleScroll, { passive: true })
+    window.addEventListener('scroll', requestUpdate, { passive: true })
+    // Resize changes the scrollable height without firing a scroll event.
+    window.addEventListener('resize', requestUpdate)
     updateScrollState()
 
     return () => {
-      window.removeEventListener('scroll', handleScroll)
+      window.removeEventListener('scroll', requestUpdate)
+      window.removeEventListener('resize', requestUpdate)
       if (frame !== null) window.cancelAnimationFrame(frame)
     }
   }, [])
@@ -86,25 +103,36 @@ export default function Header() {
     if (!isMenuOpen) return
 
     const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.key === 'Escape') setIsMenuOpen(false)
+      if (event.key === 'Escape') {
+        setIsMenuOpen(false)
+        // Closing unmounts the dropdown; without this, focus falls to <body>.
+        menuButtonRef.current?.focus()
+      }
     }
 
+    // Above lg the dropdown and its toggle are display:none; leaving the menu
+    // "open" there would pin the opaque header chrome with no way to dismiss it.
+    const desktopQuery = window.matchMedia('(min-width: 1024px)')
+    const handleBreakpointChange = () => {
+      if (desktopQuery.matches) setIsMenuOpen(false)
+    }
+    handleBreakpointChange()
+
     document.addEventListener('keydown', handleKeyDown)
-    return () => document.removeEventListener('keydown', handleKeyDown)
+    desktopQuery.addEventListener('change', handleBreakpointChange)
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown)
+      desktopQuery.removeEventListener('change', handleBreakpointChange)
+    }
   }, [isMenuOpen])
 
   const closeMobile = () => setIsMenuOpen(false)
 
-  const linkClass = (item: NavItem, block = false) => {
-    const isActive = item.id && activeSection === item.id
-    return `${block ? 'flex w-full' : 'inline-flex'} min-h-11 items-center border-b-2 px-1 py-2 text-sm font-medium transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-bg ${
-      isActive ? 'text-fg border-accent' : 'text-muted border-transparent hover:text-fg'
-    }`
-  }
-
   const renderLink = (item: NavItem, onClick?: () => void, block = false) => {
-    const className = linkClass(item, block)
     const isActive = Boolean(item.id && activeSection === item.id)
+    const className = `${block ? 'flex w-full' : 'inline-flex'} focus-ring min-h-11 items-center border-b-2 px-1 py-2 text-sm font-medium transition-colors duration-200 ${
+      isActive ? 'border-accent text-fg' : 'border-transparent text-muted hover:text-fg'
+    }`
     return item.id ? (
       <a
         key={item.name}
@@ -122,6 +150,20 @@ export default function Header() {
     )
   }
 
+  const renderSocialLinks = (size: string) =>
+    socialLinks.map(({ label, href, Icon }) => (
+      <a
+        key={label}
+        href={href}
+        target="_blank"
+        rel="noopener noreferrer"
+        aria-label={label}
+        className={iconLinkClass(size)}
+      >
+        <Icon size={20} />
+      </a>
+    ))
+
   return (
     <header
       className={`fixed left-0 right-0 top-0 z-50 transition-all duration-300 ${
@@ -133,7 +175,7 @@ export default function Header() {
           <div className="flex-shrink-0">
             <a
               href="#home"
-              className="inline-flex min-h-11 items-center rounded-sm text-lg font-semibold tracking-tight text-fg transition-opacity hover:opacity-80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-bg xl:text-xl"
+              className="focus-ring inline-flex min-h-11 items-center rounded-sm text-lg font-semibold tracking-tight text-fg transition-opacity hover:opacity-80 xl:text-xl"
             >
               Bhargava Shastry
             </a>
@@ -146,44 +188,19 @@ export default function Header() {
           </div>
 
           <div className="hidden items-center space-x-1 lg:flex xl:space-x-2">
-            <a
-              href="https://github.com/bshastry"
-              target="_blank"
-              rel="noopener noreferrer"
-              aria-label="GitHub profile"
-              className="inline-flex h-10 w-10 items-center justify-center rounded-md text-muted transition-colors hover:text-fg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-bg"
-            >
-              <Github size={20} />
-            </a>
-            <a
-              href="https://twitter.com/ibags"
-              target="_blank"
-              rel="noopener noreferrer"
-              aria-label="Twitter profile"
-              className="inline-flex h-10 w-10 items-center justify-center rounded-md text-muted transition-colors hover:text-fg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-bg"
-            >
-              <Twitter size={20} />
-            </a>
-            <a
-              href="https://linkedin.com/in/bshastry"
-              target="_blank"
-              rel="noopener noreferrer"
-              aria-label="LinkedIn profile"
-              className="inline-flex h-10 w-10 items-center justify-center rounded-md text-muted transition-colors hover:text-fg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-bg"
-            >
-              <Linkedin size={20} />
-            </a>
+            {renderSocialLinks('h-10 w-10')}
             <ThemeToggle />
           </div>
 
           <div className="lg:hidden">
             <button
+              ref={menuButtonRef}
               type="button"
               onClick={() => setIsMenuOpen(!isMenuOpen)}
               aria-label={isMenuOpen ? 'Close navigation menu' : 'Open navigation menu'}
               aria-expanded={isMenuOpen}
               aria-controls="mobile-navigation"
-              className="inline-flex h-11 w-11 items-center justify-center rounded-md text-muted transition-colors hover:text-fg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-bg"
+              className="focus-ring inline-flex h-11 w-11 items-center justify-center rounded-md text-muted transition-colors hover:text-fg"
             >
               {isMenuOpen ? <X size={24} /> : <Menu size={24} />}
             </button>
@@ -195,43 +212,20 @@ export default function Header() {
             <div className="mb-3 mt-2 space-y-1 rounded-xl border border-line bg-surface px-3 py-3 shadow-xl shadow-black/10">
               {navigation.map((item) => renderLink(item, closeMobile, true))}
               <div className="flex items-center space-x-4 px-1 py-2">
-                <a
-                  href="https://github.com/bshastry"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  aria-label="GitHub profile"
-                  className="inline-flex h-11 w-11 items-center justify-center rounded-md text-muted transition-colors hover:text-fg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
-                >
-                  <Github size={20} />
-                </a>
-                <a
-                  href="https://twitter.com/ibags"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  aria-label="Twitter profile"
-                  className="inline-flex h-11 w-11 items-center justify-center rounded-md text-muted transition-colors hover:text-fg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
-                >
-                  <Twitter size={20} />
-                </a>
-                <a
-                  href="https://linkedin.com/in/bshastry"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  aria-label="LinkedIn profile"
-                  className="inline-flex h-11 w-11 items-center justify-center rounded-md text-muted transition-colors hover:text-fg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
-                >
-                  <Linkedin size={20} />
-                </a>
-                <ThemeToggle />
+                {renderSocialLinks('h-11 w-11')}
+                <ThemeToggle className="h-11 w-11" />
               </div>
             </div>
           </div>
         )}
       </nav>
+      {/* top-16 pins the bar to the 64px top bar even when the open mobile
+          menu grows the header. No transition: it's rewritten every frame. */}
       <span
+        ref={progressRef}
         aria-hidden="true"
-        className="absolute bottom-0 left-0 h-px w-full origin-left bg-accent transition-transform duration-150"
-        style={{ transform: `scaleX(${scrollProgress})` }}
+        className="absolute left-0 top-16 h-px w-full origin-left bg-accent"
+        style={{ transform: 'scaleX(0)' }}
       />
     </header>
   )

--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -161,7 +161,7 @@ export default function Hero({ latestPost, findingsCount, publicationsCount }: H
             {latestPost && (
               <Link
                 href={`/blog/${latestPost.slug}`}
-                className="group mt-8 inline-flex max-w-full items-center gap-2 rounded-full border border-line bg-surface/60 px-4 py-2 text-sm text-muted transition-colors hover:border-line-strong hover:text-fg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-bg"
+                className="focus-ring group mt-8 inline-flex max-w-full items-center gap-2 rounded-full border border-line bg-surface/60 px-4 py-2 text-sm text-muted transition-colors hover:border-line-strong hover:text-fg"
               >
                 <Sparkles size={14} className="flex-shrink-0 text-accent" />
                 <span className="eyebrow flex-shrink-0">Latest</span>
@@ -175,11 +175,13 @@ export default function Hero({ latestPost, findingsCount, publicationsCount }: H
               </Link>
             )}
 
-            <p
-              aria-label="Method: input to independent witnesses to divergence to evidence"
-              className="mt-8 border-l-2 border-accent pl-3 font-mono text-xs leading-relaxed text-muted lg:hidden"
-            >
-              input → independent witnesses → divergence → evidence
+            {/* aria-label is prohibited on paragraphs, so screen readers get a
+                spelled-out copy and the arrow glyphs stay visual-only. */}
+            <p className="mt-8 border-l-2 border-accent pl-3 font-mono text-xs leading-relaxed text-muted lg:hidden">
+              <span aria-hidden="true">input → independent witnesses → divergence → evidence</span>
+              <span className="sr-only">
+                Method: input, to independent witnesses, to divergence, to evidence
+              </span>
             </p>
           </div>
 
@@ -197,7 +199,7 @@ export default function Hero({ latestPost, findingsCount, publicationsCount }: H
               className={`flex min-h-28 flex-col items-center justify-center gap-2 px-4 py-6 transition-colors hover:bg-surface focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-accent ${
                 index % 2 === 1 ? 'border-l border-line' : ''
               } ${index < 2 ? 'border-b border-line md:border-b-0' : ''} ${
-                index > 0 ? 'md:border-l md:border-line' : 'md:border-l-0'
+                index > 0 ? 'md:border-l md:border-line' : ''
               }`}
             >
               <span className="font-mono text-3xl font-semibold tracking-tight text-fg sm:text-4xl">
@@ -210,7 +212,7 @@ export default function Hero({ latestPost, findingsCount, publicationsCount }: H
 
         <a
           href="#about"
-          className="mx-auto mt-8 flex w-fit items-center gap-2 rounded-sm px-3 py-2 font-mono text-xs uppercase tracking-[0.16em] text-faint transition-colors hover:text-fg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-bg"
+          className="focus-ring mx-auto mt-8 flex w-fit items-center gap-2 rounded-sm px-3 py-2 font-mono text-xs uppercase tracking-[0.16em] text-faint transition-colors hover:text-fg"
         >
           Explore the method
           <ArrowDown size={15} aria-hidden="true" />

--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import Link from 'next/link'
 import { ArrowDown, Sparkles } from 'lucide-react'
 import type { BlogPostMeta } from '@/lib/blog'
@@ -9,14 +7,99 @@ type LatestPost = Pick<BlogPostMeta, 'slug' | 'title' | 'date'>
 
 interface HeroProps {
   latestPost: LatestPost | null
-  // Counts come from the server component so this client component doesn't
-  // ship the whole portfolio JSON just to render two numbers.
   findingsCount: number
   publicationsCount: number
 }
 
+const witnesses = [
+  { name: 'implementation A', result: '0x4ab8…91e2', status: 'match' },
+  { name: 'implementation B', result: '0x4ab8…91e2', status: 'match' },
+  { name: 'implementation C', result: '0xc103…7bf4', status: 'diverged' },
+]
+
+function MethodTrace() {
+  return (
+    <aside
+      aria-label="Differential testing method, illustrated"
+      className="signal-panel relative overflow-hidden rounded-2xl border border-line bg-surface/80 p-5 shadow-2xl shadow-black/5 dark:shadow-black/30 sm:p-6"
+    >
+      <div className="flex items-center justify-between gap-4 border-b border-line pb-4">
+        <p className="eyebrow text-accent">Method / one trace</p>
+        <span className="font-mono text-[11px] uppercase tracking-wider text-faint">
+          illustrative
+        </span>
+      </div>
+
+      <ol className="mt-5 space-y-4">
+        <li className="grid grid-cols-[2rem_1fr] gap-3">
+          <span className="font-mono text-xs text-accent">01</span>
+          <div>
+            <p className="text-sm font-medium text-fg">Generate one valid input</p>
+            <p className="mt-1 font-mono text-xs leading-relaxed text-faint">
+              state_test(seed=0x8f2a)
+            </p>
+          </div>
+        </li>
+
+        <li className="grid grid-cols-[2rem_1fr] gap-3">
+          <span className="font-mono text-xs text-accent">02</span>
+          <div className="min-w-0">
+            <p className="text-sm font-medium text-fg">Ask independent witnesses</p>
+            <div className="mt-3 overflow-hidden rounded-lg border border-line bg-bg/70">
+              {witnesses.map((witness) => (
+                <div
+                  key={witness.name}
+                  className="grid grid-cols-[minmax(0,1fr)_auto] items-center gap-x-3 gap-y-1 border-b border-line px-3 py-2.5 font-mono text-[11px] last:border-b-0 sm:grid-cols-[minmax(0,1fr)_auto_auto] sm:text-xs"
+                >
+                  <span className="truncate text-muted">{witness.name}</span>
+                  <span
+                    className={`col-span-2 row-start-2 sm:col-span-1 sm:col-start-2 sm:row-start-1 ${
+                      witness.status === 'diverged' ? 'text-accent' : 'text-faint'
+                    }`}
+                  >
+                    {witness.result}
+                  </span>
+                  <span
+                    className={`col-start-2 row-start-1 inline-flex items-center gap-2 sm:col-start-3 ${
+                      witness.status === 'diverged' ? 'text-accent' : 'text-faint'
+                    }`}
+                  >
+                    <span
+                      aria-hidden="true"
+                      className={`h-1.5 w-1.5 rounded-full ${
+                        witness.status === 'diverged'
+                          ? 'bg-accent shadow-[0_0_0_4px_rgb(var(--accent)/0.14)]'
+                          : 'bg-faint'
+                      }`}
+                    />
+                    {witness.status}
+                  </span>
+                </div>
+              ))}
+            </div>
+          </div>
+        </li>
+
+        <li className="grid grid-cols-[2rem_1fr] gap-3">
+          <span className="font-mono text-xs text-accent">03</span>
+          <div>
+            <p className="text-sm font-medium text-fg">Minimize, reproduce, report</p>
+            <p className="mt-1 text-sm leading-relaxed text-muted">
+              Turn a disagreement into a regression test and an upstream fix.
+            </p>
+          </div>
+        </li>
+      </ol>
+
+      <div className="mt-6 flex items-center gap-3 border-t border-line pt-4">
+        <span aria-hidden="true" className="h-px w-8 bg-accent" />
+        <p className="font-mono text-xs text-muted">evidence, not intuition</p>
+      </div>
+    </aside>
+  )
+}
+
 export default function Hero({ latestPost, findingsCount, publicationsCount }: HeroProps) {
-  // Every number links to the evidence behind it — no unexplained totals.
   const stats = [
     { value: '10+', label: 'years in security', href: '#about' },
     {
@@ -29,106 +112,109 @@ export default function Hero({ latestPost, findingsCount, publicationsCount }: H
     { value: String(publicationsCount), label: 'publications', href: '#publications' },
   ]
 
-  const scrollToAbout = () => {
-    const element = document.getElementById('about')
-    if (element) {
-      element.scrollIntoView({ behavior: 'smooth' })
-    }
-  }
-
   return (
-    <section id="home" className="flex min-h-screen items-center justify-center bg-bg pt-16">
-      {/* min-w-0 lets the latest-post pill's nowrap title truncate instead of
-          inflating this flex item's min-content width past the viewport. */}
-      <div className="container-max section-padding w-full min-w-0">
-        <div className="animate-fade-in text-center">
-          {/* Main heading */}
-          <h1 className="text-6xl font-semibold tracking-tight text-fg md:text-8xl">
-            <span className="block">Bhargava</span>
-            <span className="block text-accent">Shastry</span>
-          </h1>
+    <section
+      id="home"
+      className="relative isolate flex min-h-[100svh] items-center overflow-hidden border-b border-line bg-bg pt-16"
+    >
+      <div aria-hidden="true" className="hero-grid pointer-events-none absolute inset-0 -z-10" />
 
-          {/* Defining statement */}
-          <p className="mx-auto mt-8 max-w-3xl text-xl text-muted md:text-2xl">
-            I find <span className="text-accent">cross-implementation failures</span> before they
-            become production incidents — differential testing of Ethereum clients, cryptographic
-            libraries, and compilers that turns disagreement between systems into reproducible
-            evidence.
-          </p>
+      <div className="container-max section-padding w-full py-16 sm:py-20 lg:py-24">
+        <div className="grid items-center gap-12 lg:grid-cols-[minmax(0,1.12fr)_minmax(20rem,0.88fr)] lg:gap-16">
+          <div className="min-w-0 animate-fade-in">
+            <p className="eyebrow flex items-center gap-3 text-accent">
+              <span aria-hidden="true" className="h-1.5 w-1.5 rounded-full bg-accent" />
+              Protocol security · differential testing
+            </p>
 
-          {/* Proof line */}
-          <p className="mx-auto mt-6 max-w-2xl text-sm leading-relaxed text-faint">
-            Security Engineer at the Ethereum Foundation. Beyond the day job, I design and build
-            AI-driven triage and vulnerability-discovery pipelines that scale this method — agentic
-            systems with auditable logs and human review at the decision points.
-          </p>
+            <h1 className="mt-6 text-[clamp(3.75rem,8vw,6.75rem)] font-semibold leading-[0.88] tracking-[-0.055em] text-fg">
+              <span className="block">Bhargava</span>
+              <span className="block text-accent">Shastry</span>
+            </h1>
 
-          {/* Latest activity */}
-          {latestPost && (
-            <Link
-              href={`/blog/${latestPost.slug}`}
-              className="group mx-auto mt-8 inline-flex max-w-full items-center gap-2 rounded-full border border-line px-4 py-2 text-sm text-muted transition-colors hover:border-line-strong hover:text-fg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
-            >
-              <Sparkles size={14} className="flex-shrink-0 text-accent" />
-              <span className="eyebrow flex-shrink-0">Latest</span>
-              <span className="truncate">{latestPost.title}</span>
-              <time
-                dateTime={latestPost.date}
-                className="flex-shrink-0 font-mono text-xs text-faint"
-              >
-                {formatDate(latestPost.date, { year: 'numeric', month: 'short' })}
-              </time>
-            </Link>
-          )}
+            <p className="mt-8 max-w-2xl text-xl leading-relaxed text-muted sm:text-2xl">
+              I find <span className="font-medium text-accent">cross-implementation failures</span>{' '}
+              before they become production incidents — turning disagreement between Ethereum
+              clients, cryptographic libraries, and compilers into reproducible evidence.
+            </p>
 
-          {/* Stats row — each stat links to its evidence */}
-          <div className="mx-auto mt-16 grid max-w-4xl grid-cols-2 divide-line border-y border-line md:grid-cols-4 md:divide-x">
-            {stats.map((stat) => (
-              <a
-                key={stat.label}
-                href={stat.href}
-                {...(stat.external ? { target: '_blank', rel: 'noopener noreferrer' } : {})}
-                className="flex flex-col items-center gap-2 px-4 py-8 transition-colors hover:bg-surface focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-accent"
-              >
-                <span className="font-mono text-4xl font-semibold tracking-tight text-fg md:text-5xl">
-                  {stat.value}
-                </span>
-                <span className="eyebrow">{stat.label}</span>
+            <p className="mt-6 max-w-xl text-sm leading-relaxed text-faint">
+              Security Engineer at the Ethereum Foundation. Beyond the day job, I design AI-driven
+              triage and vulnerability-discovery pipelines with auditable logs and human review at
+              the decision points.
+            </p>
+
+            <div className="mt-8 flex flex-col items-start gap-3 sm:flex-row">
+              <a href="#case-studies" className="btn-primary px-6 py-3">
+                See case studies
               </a>
-            ))}
+              <a href="#contact" className="btn-ghost px-6 py-3">
+                Discuss a scoped review
+              </a>
+            </div>
+
+            <p className="mt-5 max-w-xl text-xs leading-relaxed text-faint">
+              Independent engagements are limited and subject to conflict review. Employer
+              affiliation does not imply endorsement.
+            </p>
+
+            {latestPost && (
+              <Link
+                href={`/blog/${latestPost.slug}`}
+                className="group mt-8 inline-flex max-w-full items-center gap-2 rounded-full border border-line bg-surface/60 px-4 py-2 text-sm text-muted transition-colors hover:border-line-strong hover:text-fg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-bg"
+              >
+                <Sparkles size={14} className="flex-shrink-0 text-accent" />
+                <span className="eyebrow flex-shrink-0">Latest</span>
+                <span className="truncate">{latestPost.title}</span>
+                <time
+                  dateTime={latestPost.date}
+                  className="hidden flex-shrink-0 font-mono text-xs text-faint sm:inline"
+                >
+                  {formatDate(latestPost.date, { year: 'numeric', month: 'short' })}
+                </time>
+              </Link>
+            )}
+
+            <p
+              aria-label="Method: input to independent witnesses to divergence to evidence"
+              className="mt-8 border-l-2 border-accent pl-3 font-mono text-xs leading-relaxed text-muted lg:hidden"
+            >
+              input → independent witnesses → divergence → evidence
+            </p>
           </div>
 
-          {/* CTA Buttons */}
-          <div className="mt-16 flex flex-col justify-center gap-4 sm:flex-row">
-            <a
-              href="#case-studies"
-              className="btn-primary px-6 py-3 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
-            >
-              See case studies
-            </a>
-            <a
-              href="#contact"
-              className="btn-ghost px-6 py-3 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
-            >
-              Discuss a scoped review
-            </a>
+          <div className="hidden animate-slide-up lg:block lg:pl-2">
+            <MethodTrace />
           </div>
-
-          {/* Independence qualifier */}
-          <p className="mx-auto mt-6 max-w-xl text-xs leading-relaxed text-faint">
-            Independent engagements are limited and subject to conflict review. Employer affiliation
-            does not imply endorsement.
-          </p>
-
-          {/* Scroll indicator */}
-          <button
-            onClick={scrollToAbout}
-            className="mt-16 animate-bounce text-faint transition-colors duration-200 hover:text-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
-            aria-label="Scroll to about section"
-          >
-            <ArrowDown size={24} />
-          </button>
         </div>
+
+        <div className="mt-14 grid grid-cols-2 overflow-hidden rounded-xl border border-line bg-surface/50 md:grid-cols-4">
+          {stats.map((stat, index) => (
+            <a
+              key={stat.label}
+              href={stat.href}
+              {...(stat.external ? { target: '_blank', rel: 'noopener noreferrer' } : {})}
+              className={`flex min-h-28 flex-col items-center justify-center gap-2 px-4 py-6 transition-colors hover:bg-surface focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-accent ${
+                index % 2 === 1 ? 'border-l border-line' : ''
+              } ${index < 2 ? 'border-b border-line md:border-b-0' : ''} ${
+                index > 0 ? 'md:border-l md:border-line' : 'md:border-l-0'
+              }`}
+            >
+              <span className="font-mono text-3xl font-semibold tracking-tight text-fg sm:text-4xl">
+                {stat.value}
+              </span>
+              <span className="eyebrow text-center">{stat.label}</span>
+            </a>
+          ))}
+        </div>
+
+        <a
+          href="#about"
+          className="mx-auto mt-8 flex w-fit items-center gap-2 rounded-sm px-3 py-2 font-mono text-xs uppercase tracking-[0.16em] text-faint transition-colors hover:text-fg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-bg"
+        >
+          Explore the method
+          <ArrowDown size={15} aria-hidden="true" />
+        </a>
       </div>
     </section>
   )

--- a/components/ThemeToggle.tsx
+++ b/components/ThemeToggle.tsx
@@ -8,7 +8,9 @@ import { Moon, Sun } from 'lucide-react'
  * applied pre-paint by the inline script in app/layout.tsx. Renders a stable
  * placeholder until mounted to avoid a hydration mismatch.
  */
-export default function ThemeToggle({ className = '' }: { className?: string }) {
+// className replaces the default size wholesale so callers can match sibling
+// hit targets (e.g. the 44px mobile-menu row) without fighting class order.
+export default function ThemeToggle({ className = 'h-10 w-10' }: { className?: string }) {
   const [mounted, setMounted] = useState(false)
   const [isDark, setIsDark] = useState(true)
 
@@ -29,7 +31,7 @@ export default function ThemeToggle({ className = '' }: { className?: string }) 
     setIsDark(next)
   }
 
-  const base = `inline-flex h-10 w-10 items-center justify-center rounded-md text-muted transition-colors hover:text-fg focus:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-bg ${className}`
+  const base = `focus-ring inline-flex items-center justify-center rounded-md text-muted transition-colors hover:text-fg focus:outline-none ${className}`
 
   if (!mounted) {
     return <span className={base} aria-hidden="true" />

--- a/components/ThemeToggle.tsx
+++ b/components/ThemeToggle.tsx
@@ -29,7 +29,7 @@ export default function ThemeToggle({ className = '' }: { className?: string }) 
     setIsDark(next)
   }
 
-  const base = `inline-flex h-9 w-9 items-center justify-center rounded-md text-muted transition-colors hover:text-fg focus:outline-none focus-visible:ring-2 focus-visible:ring-accent ${className}`
+  const base = `inline-flex h-10 w-10 items-center justify-center rounded-md text-muted transition-colors hover:text-fg focus:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-bg ${className}`
 
   if (!mounted) {
     return <span className={base} aria-hidden="true" />

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -35,7 +35,7 @@ module.exports = {
         },
       },
       fontFamily: {
-        sans: ['Inter', 'system-ui', 'sans-serif'],
+        sans: ['var(--font-inter)', 'system-ui', 'sans-serif'],
         mono: [
           'ui-monospace',
           'SFMono-Regular',

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -36,7 +36,15 @@ module.exports = {
       },
       fontFamily: {
         sans: ['Inter', 'system-ui', 'sans-serif'],
-        mono: ['JetBrains Mono', 'monospace'],
+        mono: [
+          'ui-monospace',
+          'SFMono-Regular',
+          'Cascadia Code',
+          'Roboto Mono',
+          'Menlo',
+          'Consolas',
+          'monospace',
+        ],
       },
       animation: {
         'fade-in': 'fadeIn 0.5s ease-in-out',


### PR DESCRIPTION
## Summary

Applies an uploaded design/accessibility patch that raises the visual quality of the portfolio landing page and hardens accessibility across the header, hero, about, and case-studies sections.

- **Hero**: converts to a server component (removes `'use client'` and the JS scroll handler), adds a two-column layout with an illustrative "method trace" panel, a systems-grid background motif, and a restructured stats band.
- **Header**: adds a scroll-progress bar (rAF-throttled scroll handler), Escape-to-close for the mobile menu, `aria-current`/`aria-controls` wiring, larger touch targets (44px), and moves the desktop nav breakpoint from `md` to `lg`.
- **Accessibility**: consistent `focus-visible` rings with offsets, `prefers-reduced-motion` and `prefers-contrast: more` support, `color-scheme` hints, `scroll-padding-top` for anchor navigation.
- **Performance**: drops the render-blocking Google Fonts CSS `@import` (Inter is already self-hosted via `next/font`; mono now uses a system font stack).
- **Case studies / About**: card treatment with numbered entries and section surface tinting.

## Testing

- `npm run typecheck` — passes
- `npm run lint` — passes
- `npm run format:check` — passes
- `npm run build` — static export builds all routes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTVUzy5R8YZHc6Y6fLRvQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01LoTVUzy5R8YZHc6Y6fLRvQ)_