### PR TITLE
Implement site improvement plan: evidence-led hero, timeline, professional contact flow

### DIFF
--- a/app/blog/BlogIndexClient.tsx
+++ b/app/blog/BlogIndexClient.tsx
@@ -13,6 +13,8 @@ interface BlogIndexClientProps {
   posts: BlogPostMeta[]
 }
 
+const START_HERE_SLUG = 'trust-no-single-witness'
+
 const chipClass = (active: boolean) =>
   `chip transition-colors focus-visible:ring-2 focus-visible:ring-accent ${
     active ? 'border-accent text-accent' : ''
@@ -24,7 +26,9 @@ export default function BlogIndexClient({ posts }: BlogIndexClientProps) {
 
   // Granular tags stay in post metadata; readers navigate six collections.
   const { annotatedPosts, visibleCollections } = useMemo(() => {
-    const annotated = posts.map((p) => ({ ...p, collection: collectionFor(p.tags) }))
+    const annotated = posts
+      .map((p) => ({ ...p, collection: collectionFor(p.tags) }))
+      .sort((a, b) => Number(b.slug === START_HERE_SLUG) - Number(a.slug === START_HERE_SLUG))
     return {
       annotatedPosts: annotated,
       visibleCollections: COLLECTIONS.filter((c) => annotated.some((p) => p.collection === c)),
@@ -131,6 +135,9 @@ export default function BlogIndexClient({ posts }: BlogIndexClientProps) {
             {filteredPosts.map((post) => (
               <article key={post.slug} className="py-10">
                 <div className="mb-4 flex flex-wrap items-center gap-x-4 gap-y-2 text-sm text-faint">
+                  {post.slug === START_HERE_SLUG && (
+                    <span className="chip border-accent text-accent">Start here</span>
+                  )}
                   <span className="flex items-center">
                     <Calendar size={16} className="mr-2" />
                     <time dateTime={post.date}>{formatDate(post.date)}</time>

--- a/app/blog/BlogIndexClient.tsx
+++ b/app/blog/BlogIndexClient.tsx
@@ -13,8 +13,6 @@ interface BlogIndexClientProps {
   posts: BlogPostMeta[]
 }
 
-const START_HERE_SLUG = 'trust-no-single-witness'
-
 const chipClass = (active: boolean) =>
   `chip transition-colors focus-visible:ring-2 focus-visible:ring-accent ${
     active ? 'border-accent text-accent' : ''
@@ -26,9 +24,10 @@ export default function BlogIndexClient({ posts }: BlogIndexClientProps) {
 
   // Granular tags stay in post metadata; readers navigate six collections.
   const { annotatedPosts, visibleCollections } = useMemo(() => {
+    // Stable sort: pinned posts float to the top, everything else keeps date order.
     const annotated = posts
       .map((p) => ({ ...p, collection: collectionFor(p.tags) }))
-      .sort((a, b) => Number(b.slug === START_HERE_SLUG) - Number(a.slug === START_HERE_SLUG))
+      .sort((a, b) => Number(b.pinned ?? false) - Number(a.pinned ?? false))
     return {
       annotatedPosts: annotated,
       visibleCollections: COLLECTIONS.filter((c) => annotated.some((p) => p.collection === c)),
@@ -135,7 +134,7 @@ export default function BlogIndexClient({ posts }: BlogIndexClientProps) {
             {filteredPosts.map((post) => (
               <article key={post.slug} className="py-10">
                 <div className="mb-4 flex flex-wrap items-center gap-x-4 gap-y-2 text-sm text-faint">
-                  {post.slug === START_HERE_SLUG && (
+                  {post.pinned && (
                     <span className="chip border-accent text-accent">Start here</span>
                   )}
                   <span className="flex items-center">

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,11 +1,19 @@
 import type { Metadata } from 'next'
-import { Inter } from 'next/font/google'
+import { Inter, JetBrains_Mono } from 'next/font/google'
 import { pageAlternates } from '@/lib/seo'
 import './globals.css'
 
 // The CSS variable keeps Tailwind's font-sans token pointing at the self-hosted
 // next/font family; nothing else loads a face literally named "Inter".
 const inter = Inter({ subsets: ['latin'], variable: '--font-inter' })
+const jetbrainsMono = JetBrains_Mono({
+  subsets: ['latin'],
+  weight: ['400', '500'],
+  variable: '--font-jetbrains-mono',
+})
+
+const siteDescription =
+  'Security engineer at the Ethereum Foundation. Differential testing of Ethereum clients, post-quantum cryptography, and compilers — plus the AI-assisted triage pipelines that scale it.'
 
 export const metadata: Metadata = {
   metadataBase: new URL('https://bshastry.github.io'),
@@ -13,8 +21,7 @@ export const metadata: Metadata = {
     default: 'Bhargava Shastry — Security Engineer & Researcher',
     template: '%s — Bhargava Shastry',
   },
-  description:
-    'Differential testing for critical protocol and cryptographic implementations — finding cross-implementation failures in Ethereum clients, cryptographic libraries, and compilers before they become production incidents.',
+  description: siteDescription,
   keywords: [
     'differential testing',
     'differential fuzzing',
@@ -34,14 +41,12 @@ export const metadata: Metadata = {
     url: 'https://bshastry.github.io',
     siteName: 'Bhargava Shastry',
     title: 'Bhargava Shastry — Security Engineer & Researcher',
-    description:
-      'Differential testing for critical protocol and cryptographic implementations — finding cross-implementation failures before they become production incidents.',
+    description: siteDescription,
   },
   twitter: {
     card: 'summary_large_image',
     title: 'Bhargava Shastry — Security Engineer & Researcher',
-    description:
-      'Differential testing for critical protocol and cryptographic implementations — finding cross-implementation failures before they become production incidents.',
+    description: siteDescription,
     creator: '@ibags',
   },
 }
@@ -60,7 +65,11 @@ const themeScript = `
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
-    <html lang="en" className={`dark scroll-smooth ${inter.variable}`} suppressHydrationWarning>
+    <html
+      lang="en"
+      className={`dark scroll-smooth ${inter.variable} ${jetbrainsMono.variable}`}
+      suppressHydrationWarning
+    >
       <head>
         <script dangerouslySetInnerHTML={{ __html: themeScript }} />
       </head>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,19 +1,21 @@
 import type { Metadata } from 'next'
 import { Inter, JetBrains_Mono } from 'next/font/google'
 import { pageAlternates } from '@/lib/seo'
+import portfolioData from '@/data/portfolio.json'
 import './globals.css'
 
 // The CSS variable keeps Tailwind's font-sans token pointing at the self-hosted
 // next/font family; nothing else loads a face literally named "Inter".
 const inter = Inter({ subsets: ['latin'], variable: '--font-inter' })
+// 400 covers eyebrows/chips/body mono; 600 gives the hero stat digits a real
+// semibold face instead of browser-synthesized bold.
 const jetbrainsMono = JetBrains_Mono({
   subsets: ['latin'],
-  weight: ['400', '500'],
+  weight: ['400', '600'],
   variable: '--font-jetbrains-mono',
 })
 
-const siteDescription =
-  'Security engineer at the Ethereum Foundation. Differential testing of Ethereum clients, post-quantum cryptography, and compilers — plus the AI-assisted triage pipelines that scale it.'
+const siteDescription = portfolioData.personal.description
 
 export const metadata: Metadata = {
   metadataBase: new URL('https://bshastry.github.io'),

--- a/components/About.tsx
+++ b/components/About.tsx
@@ -1,31 +1,35 @@
+import Link from 'next/link'
 import { FileDown } from 'lucide-react'
+import portfolioData from '@/data/portfolio.json'
+
+const expertise = [
+  'Differential Testing & Fuzzing',
+  'AI-Driven Triage & Vuln Discovery',
+  'Ethereum Protocol Security',
+  'Post-Quantum Cryptography',
+  'Side-Channel Analysis',
+  'Bug Bounty Triage',
+]
+
+const technologies = [
+  'Go',
+  'Rust',
+  'C++',
+  'Python',
+  'Solidity',
+  'Ethereum',
+  'EVM',
+  'goevmlab',
+  'libFuzzer',
+  'cargo-fuzz',
+  'AFL',
+  'Foundry',
+  'Docker',
+  'LLM Agents',
+]
 
 export default function About() {
-  const expertise = [
-    'Differential Testing & Fuzzing',
-    'AI-Driven Triage & Vuln Discovery',
-    'Ethereum Protocol Security',
-    'Post-Quantum Cryptography',
-    'Side-Channel Analysis',
-    'Bug Bounty Triage',
-  ]
-
-  const technologies = [
-    'Go',
-    'Rust',
-    'C++',
-    'Python',
-    'Solidity',
-    'Ethereum',
-    'EVM',
-    'goevmlab',
-    'libFuzzer',
-    'cargo-fuzz',
-    'AFL',
-    'Foundry',
-    'Docker',
-    'LLM Agents',
-  ]
+  const { experience, education } = portfolioData
 
   return (
     <section id="about" className="bg-bg py-24 md:py-28">
@@ -36,66 +40,107 @@ export default function About() {
         </div>
 
         <div className="mb-16 grid grid-cols-1 gap-12 lg:grid-cols-2 lg:gap-16">
-          {/* Prose */}
           <div>
-            <h3 className="mb-5 text-2xl font-semibold text-fg">
-              Turning disagreement into evidence
-            </h3>
+            <blockquote className="mb-8 border-l-2 border-accent pl-5">
+              <p className="text-xl font-semibold leading-relaxed text-fg sm:text-2xl">
+                “In a system with more than one implementation there is no ground truth — only
+                witnesses that disagree. So: trust no single witness.”
+              </p>
+              <Link
+                href="/blog/trust-no-single-witness"
+                className="link-accent mt-3 inline-flex text-sm font-medium"
+              >
+                Read the long version →
+              </Link>
+            </blockquote>
+
             <p className="mb-5 text-lg leading-relaxed text-fg">
-              My working thesis: in a system with more than one implementation there is no ground
-              truth — only witnesses that can disagree. I make them disagree under controlled
-              conditions. I build coverage-guided differential fuzzers that run Ethereum&apos;s
-              execution clients, post-quantum cryptography libraries, and compilers against each
-              other, so every divergence becomes a reproducible bug report before it becomes a
-              production incident.
+              That&apos;s the whole method. I make the witnesses disagree under controlled
+              conditions: coverage-guided differential fuzzers that run Ethereum&apos;s execution
+              clients, post-quantum cryptography libraries, and compilers against each other, so
+              every divergence becomes a reproducible bug report.
             </p>
             <p className="mb-4 leading-relaxed text-muted">
               I practice this as a security engineer at the Ethereum Foundation — differential
               fuzzing of execution clients, hard-fork readiness testing, and bug-bounty triage. To
-              scale the method, I design and build AI-driven pipelines that decompose vulnerability
-              research into context building, harness generation, PoC validation, and triage:
-              deterministic orchestration, auditable logs, and human review at the decision points.
+              scale the method, I build AI-assisted pipelines for context building, harness
+              generation, PoC validation, and triage, with deterministic orchestration, auditable
+              logs and human review at the decision points.
             </p>
             <p className="leading-relaxed text-muted">
-              The method has deep roots — a Ph.D. on fuzzing and static analysis at TU Berlin, 300+
-              commits to the Solidity compiler&apos;s fuzzing infrastructure, contributions to
-              Google&apos;s OSS-Fuzz — and I work in the open where I can: upstream fixes merged in
-              Erigon, Nethermind, revm, and the executable Ethereum specs, most recently
-              cross-checking post-quantum cryptography implementations against each other.
+              The roots are a Ph.D. in fuzzing and static analysis at TU Berlin, Solidity compiler
+              fuzzing infrastructure, and contributions to Google&apos;s OSS-Fuzz; the timeline
+              below carries the rest of the history.
             </p>
           </div>
 
-          {/* Expertise + CV */}
-          <div className="h-fit space-y-8 rounded-xl border border-line bg-surface/50 p-6 sm:p-8">
-            <div>
-              <h4 className="mb-4 text-lg font-semibold text-fg">Core Expertise</h4>
-              <ul className="grid grid-cols-1 gap-x-8 gap-y-2 sm:grid-cols-2">
-                {expertise.map((item) => (
-                  <li key={item} className="flex items-baseline gap-2 font-mono text-sm text-fg">
-                    <span aria-hidden="true" className="text-accent">
-                      &rsaquo;
-                    </span>
-                    <span>{item}</span>
-                  </li>
-                ))}
-              </ul>
-            </div>
-
-            <a
-              href="/media/Bhargava_Shastry_CV.pdf"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="btn-ghost inline-flex items-center gap-2 px-5 py-2.5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
-            >
-              <FileDown size={16} />
-              <span>Download CV (PDF)</span>
-            </a>
+          <div className="h-fit rounded-xl border border-line bg-surface/50 p-6 sm:p-8">
+            <h3 className="mb-4 text-lg font-semibold text-fg">Core Expertise</h3>
+            <ul className="grid grid-cols-1 gap-x-8 gap-y-2 sm:grid-cols-2">
+              {expertise.map((item) => (
+                <li key={item} className="flex items-baseline gap-2 font-mono text-sm text-fg">
+                  <span aria-hidden="true" className="text-accent">
+                    &rsaquo;
+                  </span>
+                  <span>{item}</span>
+                </li>
+              ))}
+            </ul>
           </div>
         </div>
 
-        {/* Technologies */}
+        <div className="mb-16">
+          <div className="grid grid-cols-1 gap-12 md:grid-cols-2 md:gap-16">
+            <div>
+              <h3 className="mb-5 text-2xl font-semibold text-fg">Experience</h3>
+              <div className="border-t border-line">
+                {experience.map((entry) => (
+                  <article
+                    key={`${entry.company}-${entry.period}`}
+                    className="border-b border-line py-5"
+                  >
+                    <p className="font-mono text-xs text-faint">{entry.period}</p>
+                    <h4 className="mt-1 font-medium text-fg">
+                      {entry.title} · {entry.company}
+                    </h4>
+                    <p className="mt-1 text-sm leading-relaxed text-muted">{entry.description}</p>
+                  </article>
+                ))}
+              </div>
+            </div>
+
+            <div>
+              <h3 className="mb-5 text-2xl font-semibold text-fg">Education</h3>
+              <div className="border-t border-line">
+                {education.map((entry) => (
+                  <article
+                    key={`${entry.institution}-${entry.year}`}
+                    className="border-b border-line py-5"
+                  >
+                    <p className="font-mono text-xs text-faint">{entry.year}</p>
+                    <h4 className="mt-1 font-medium text-fg">
+                      {entry.degree} · {entry.institution}
+                    </h4>
+                    <p className="mt-1 text-sm leading-relaxed text-muted">{entry.focus}</p>
+                  </article>
+                ))}
+              </div>
+            </div>
+          </div>
+
+          <a
+            href="/media/Bhargava_Shastry_CV.pdf"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="btn-ghost mt-8 inline-flex items-center gap-2 px-5 py-2.5"
+          >
+            <FileDown size={16} />
+            <span>Download CV (PDF)</span>
+          </a>
+        </div>
+
         <div>
-          <h3 className="mb-6 text-2xl font-semibold text-fg">Technologies & Tools</h3>
+          <h3 className="mb-6 text-2xl font-semibold text-fg">Technologies &amp; Tools</h3>
           <div className="flex flex-wrap gap-2">
             {technologies.map((tech) => (
               <span key={tech} className="chip">

--- a/components/About.tsx
+++ b/components/About.tsx
@@ -129,7 +129,7 @@ export default function About() {
           </div>
 
           <a
-            href="/media/Bhargava_Shastry_CV.pdf"
+            href={portfolioData.personal.cv}
             target="_blank"
             rel="noopener noreferrer"
             className="btn-ghost mt-8 inline-flex items-center gap-2 px-5 py-2.5"

--- a/components/CaseStudies.tsx
+++ b/components/CaseStudies.tsx
@@ -47,13 +47,14 @@ export default function CaseStudies() {
                   <dd className="text-sm leading-relaxed text-muted">{cs.result}</dd>
                 </div>
               </dl>
-              <div className="mt-7 flex flex-wrap items-center gap-x-6 gap-y-3 border-t border-line pt-5">
-                <span className="font-mono text-xs text-faint">{cs.demonstrates}</span>
-                <span className="flex flex-wrap items-center gap-4">
+              <div className="mt-7 border-t border-line pt-5">
+                <p className="eyebrow mb-2 text-accent">Demonstrates</p>
+                <p className="max-w-3xl text-sm leading-relaxed text-muted">{cs.demonstrates}</p>
+                <div className="mt-4 flex flex-wrap items-center gap-4">
                   {cs.evidence.map((link) => (
                     <ThemeLink key={link.url} link={{ ...link, type: 'external' }} />
                   ))}
-                </span>
+                </div>
               </div>
             </article>
           ))}

--- a/components/Contact.tsx
+++ b/components/Contact.tsx
@@ -1,26 +1,42 @@
-import { Mail, FlaskConical, ShieldCheck, Key, GraduationCap } from 'lucide-react'
+import {
+  FileDown,
+  FlaskConical,
+  GraduationCap,
+  Key,
+  Linkedin,
+  Mail,
+  ShieldCheck,
+} from 'lucide-react'
 import portfolioData from '@/data/portfolio.json'
 
 const engagements = [
   {
     icon: FlaskConical,
     title: 'Differential-testing diagnostic',
-    description:
-      'A bounded entry engagement for teams that suspect cross-implementation or oracle risk: a threat and divergence model, a target matrix, a harness and coverage roadmap, and a prioritized-risk debrief.',
+    mechanics: 'Fixed scope · timing confirmed in proposal',
+    audience: 'For teams that suspect cross-implementation or oracle risk.',
+    deliverables:
+      'A divergence and threat model, a target matrix, a harness and coverage roadmap, and a prioritized-risk debrief — the same artifact structure as the case studies above.',
   },
   {
     icon: ShieldCheck,
     title: 'Critical implementation review',
-    description:
-      'For teams approaching a hard fork, protocol upgrade, or cryptographic rollout: independent testing of high-consequence behavior, reproducible findings with severity analysis, and remediation verification.',
+    mechanics: 'Milestone-bound scope · timing confirmed in proposal',
+    audience: 'For teams approaching a hard fork, protocol upgrade, or cryptographic rollout.',
+    deliverables:
+      'Independent tests of high-consequence behavior, reproducible findings with severity analysis, and remediation verification.',
   },
   {
     icon: GraduationCap,
     title: 'Team workshop & advisory',
-    description:
-      'For security and engineering teams building their own fuzzing or differential-testing capability: a tailored workshop with exercises and reference material, plus follow-up office hours.',
+    mechanics: 'Tailored session · follow-up office hours',
+    audience: 'For teams building their own fuzzing or differential-testing capability.',
+    deliverables:
+      'A tailored workshop with practical exercises and reference material, followed by focused office hours.',
   },
 ]
+
+const process = ['Inquiry', 'Conflict check', 'Scoped proposal', 'Delivery & debrief']
 
 // Structured inquiry template (agreed qualification fields, nothing sensitive).
 // A prefilled mailto keeps the site static and the privacy page truthful.
@@ -43,81 +59,124 @@ export default function Contact() {
   return (
     <section id="contact" className="border-t border-line py-24 md:py-28">
       <div className="container-max section-padding">
-        <div className="mb-16">
+        <div>
           <p className="eyebrow mb-4">08 — Work</p>
           <h2 className="section-title">Work with me</h2>
-          <p className="mt-4 max-w-2xl text-lg text-muted">
-            For protocol, infrastructure, and cryptographic implementation teams that need
-            independent evidence their critical implementations behave consistently before release.
-            I take on a small number of engagements, in three shapes:
+          <p className="mt-4 max-w-3xl text-lg leading-relaxed text-muted">
+            I&apos;m a security engineer at the Ethereum Foundation. Beyond that, I&apos;m glad to
+            hear about roles and teams working on hard verification problems, research
+            collaboration, conference talks, and podcasts — no formality needed, just email.
+          </p>
+
+          <div className="mt-6 flex flex-wrap items-center gap-x-6 gap-y-3 text-sm">
+            <a href={`mailto:${email}`} className="link-accent inline-flex items-center gap-2">
+              <Mail size={15} />
+              {email}
+            </a>
+            <a
+              href={`https://linkedin.com/in/${social.linkedin}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="link-accent inline-flex items-center gap-2"
+            >
+              <Linkedin size={15} />
+              LinkedIn
+            </a>
+            <a
+              href="/media/Bhargava_Shastry_CV.pdf"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="link-accent inline-flex items-center gap-2"
+            >
+              <FileDown size={15} />
+              CV (PDF)
+            </a>
+          </div>
+
+          <p className="mt-8 max-w-3xl border-l-2 border-accent pl-4 text-sm leading-relaxed text-muted">
+            My work has been merged upstream by the Nethermind, Erigon, revm, Mbed TLS, and Solidity
+            teams — the review threads are public.
           </p>
         </div>
 
-        <div className="grid grid-cols-1 gap-8 md:grid-cols-3">
-          {engagements.map((item) => (
-            <div key={item.title} className="border-t border-line pt-6">
-              <item.icon size={20} className="mb-4 text-accent" aria-hidden="true" />
-              <h3 className="mb-2 text-lg font-semibold text-fg">{item.title}</h3>
-              <p className="text-sm leading-relaxed text-muted">{item.description}</p>
+        <div className="mt-16 border-t border-line pt-12">
+          <p className="eyebrow mb-3 text-accent">Independent engagements — limited</p>
+          <h3 className="text-2xl font-semibold text-fg">Scoped security engagements</h3>
+          <p className="mt-3 max-w-2xl text-muted">
+            For teams that need independent evidence before a release, upgrade, or standardization
+            milestone.
+          </p>
+
+          <div className="mt-10 grid grid-cols-1 gap-8 md:grid-cols-3">
+            {engagements.map((item) => (
+              <article key={item.title} className="border-t border-line pt-6">
+                <item.icon size={20} className="mb-4 text-accent" aria-hidden="true" />
+                <h4 className="text-lg font-semibold text-fg">{item.title}</h4>
+                <p className="mt-1 font-mono text-xs text-accent">{item.mechanics}</p>
+                <p className="mt-4 text-sm leading-relaxed text-muted">{item.audience}</p>
+                <p className="mt-3 text-sm leading-relaxed text-muted">
+                  <strong className="font-medium text-fg">You get:</strong> {item.deliverables}
+                </p>
+              </article>
+            ))}
+          </div>
+
+          <div className="mt-10 grid grid-cols-1 gap-x-10 gap-y-6 md:grid-cols-2">
+            <div>
+              <h4 className="eyebrow mb-2">Good fit</h4>
+              <p className="text-sm leading-relaxed text-muted">
+                Multi-implementation systems — L1/L2 clients, cryptographic libraries, compilers,
+                virtual machines — approaching a release, upgrade, audit, or standardization
+                milestone, where a reproducible divergence is worth far more than an opinion.
+              </p>
             </div>
-          ))}
-        </div>
-
-        <div className="mt-10 grid grid-cols-1 gap-x-10 gap-y-6 md:grid-cols-2">
-          <div>
-            <h4 className="eyebrow mb-2">Good fit</h4>
-            <p className="text-sm leading-relaxed text-muted">
-              Multi-implementation systems — L1/L2 clients, cryptographic libraries, compilers,
-              virtual machines — approaching a release, upgrade, audit, or standardization
-              milestone, where a reproducible divergence is worth far more than an opinion.
-            </p>
+            <div>
+              <h4 className="eyebrow mb-2">Poor fit</h4>
+              <p className="text-sm leading-relaxed text-muted">
+                Smart-contract application audits, generic penetration testing, or anything that
+                conflicts with my Ethereum Foundation responsibilities — I run a conflict check
+                before any details are shared.
+              </p>
+            </div>
           </div>
-          <div>
-            <h4 className="eyebrow mb-2">Poor fit</h4>
-            <p className="text-sm leading-relaxed text-muted">
-              Smart-contract application audits, generic penetration testing, or anything that
-              conflicts with my Ethereum Foundation responsibilities — I run a conflict check before
-              any details are shared.
-            </p>
+
+          <ol className="mt-10 grid grid-cols-1 gap-px border border-line bg-line sm:grid-cols-2 lg:grid-cols-4">
+            {process.map((step, index) => (
+              <li key={step} className="flex items-center gap-3 bg-bg px-4 py-4">
+                <span className="font-mono text-xs text-accent">
+                  {String(index + 1).padStart(2, '0')}
+                </span>
+                <span className="text-sm font-medium text-fg">{step}</span>
+              </li>
+            ))}
+          </ol>
+
+          <div className="mt-8 flex flex-col items-start gap-4 sm:flex-row sm:items-center">
+            <a href={inquiryHref} className="btn-primary inline-flex items-center gap-2 px-6 py-3">
+              <Mail size={16} />
+              <span>Start a structured inquiry</span>
+            </a>
+            <a
+              href={`https://keybase.io/${social.keybase}/pgp_keys.asc`}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="btn-ghost inline-flex items-center gap-2 px-6 py-3"
+            >
+              <Key size={16} />
+              <span>PGP key for sensitive reports</span>
+            </a>
           </div>
+
+          <p className="mt-10 max-w-3xl border-l-2 border-accent pl-4 text-sm leading-relaxed text-muted">
+            Do not include vulnerability details, secrets, credentials, or source code in an inquiry
+            — use the PGP key for sensitive reports.
+          </p>
+
+          <p className="mt-8 max-w-3xl text-xs leading-relaxed text-faint">
+            Independent engagements are limited, subject to conflict review, and represent my own
+            views and work — they are not offered, endorsed, or reviewed by the Ethereum Foundation.
+          </p>
         </div>
-
-        <p className="mt-10 max-w-3xl border-l-2 border-accent pl-4 text-sm leading-relaxed text-muted">
-          Do not include vulnerability details, secrets, credentials, or source code in an inquiry —
-          use the PGP key for sensitive reports. Also open to conference talks, podcasts, and
-          research collaboration.
-        </p>
-
-        <div className="mt-8 flex flex-col items-start gap-4 sm:flex-row sm:items-center">
-          <a
-            href={inquiryHref}
-            className="btn-primary inline-flex items-center gap-2 px-6 py-3 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
-          >
-            <Mail size={16} />
-            <span>Start a structured inquiry</span>
-          </a>
-          <a
-            href={`https://keybase.io/${social.keybase}/pgp_keys.asc`}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="btn-ghost inline-flex items-center gap-2 px-6 py-3 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
-          >
-            <Key size={16} />
-            <span>PGP key for sensitive reports</span>
-          </a>
-        </div>
-
-        <p className="mt-6 text-sm text-faint">
-          Prefer plain email?{' '}
-          <a href={`mailto:${email}`} className="link-accent">
-            {email}
-          </a>
-        </p>
-
-        <p className="mt-8 max-w-3xl text-xs leading-relaxed text-faint">
-          Independent engagements are limited, subject to conflict review, and represent my own
-          views and work — they are not offered, endorsed, or reviewed by the Ethereum Foundation.
-        </p>
       </div>
     </section>
   )

--- a/components/Contact.tsx
+++ b/components/Contact.tsx
@@ -51,7 +51,7 @@ Possible conflicts (does this touch Ethereum Foundation responsibilities?):
 `
 
 export default function Contact() {
-  const { email, social } = portfolioData.personal
+  const { email, social, cv } = portfolioData.personal
   const inquiryHref = `mailto:${email}?subject=${encodeURIComponent(
     inquirySubject,
   )}&body=${encodeURIComponent(inquiryBody)}`
@@ -83,7 +83,7 @@ export default function Contact() {
               LinkedIn
             </a>
             <a
-              href="/media/Bhargava_Shastry_CV.pdf"
+              href={cv}
               target="_blank"
               rel="noopener noreferrer"
               className="link-accent inline-flex items-center gap-2"

--- a/components/Findings.tsx
+++ b/components/Findings.tsx
@@ -33,7 +33,9 @@ export default function Findings() {
               href={finding.url}
               target="_blank"
               rel="noopener noreferrer"
-              className="group flex flex-col bg-bg p-6 transition-colors hover:bg-surface focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-accent"
+              className={`group flex flex-col bg-bg p-6 transition-colors hover:bg-surface focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-accent ${
+                finding.featured ? 'border-t-2 border-accent md:col-span-2 md:p-8' : ''
+              }`}
             >
               <div className="mb-3 flex items-center justify-between gap-3">
                 <span className="chip gap-1.5">
@@ -42,7 +44,11 @@ export default function Findings() {
                 </span>
                 <span className="font-mono text-xs text-faint">{finding.date}</span>
               </div>
-              <h3 className="text-base font-semibold text-fg transition-colors group-hover:text-accent">
+              <h3
+                className={`${
+                  finding.featured ? 'text-lg' : 'text-base'
+                } font-semibold text-fg transition-colors group-hover:text-accent`}
+              >
                 {finding.title}
               </h3>
               <p className="mb-4 mt-2 flex-1 text-sm leading-relaxed text-muted">

--- a/components/Findings.tsx
+++ b/components/Findings.tsx
@@ -11,7 +11,11 @@ const typeIcons: Record<string, React.ReactNode> = {
 const fallbackTypeIcon = <FileText size={12} />
 
 export default function Findings() {
-  const { findings } = portfolioData
+  // Featured entries must lead the grid for their full-width rows to lay out
+  // cleanly; the stable sort keeps the data file's curation order otherwise.
+  const findings = [...portfolioData.findings].sort(
+    (a, b) => Number(Boolean(b.featured)) - Number(Boolean(a.featured)),
+  )
 
   return (
     <section id="findings" className="py-24 md:py-28">

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -16,8 +16,8 @@ export default function Footer() {
           <div className="md:col-span-2">
             <h3 className="mb-4 text-2xl font-semibold tracking-tight text-fg">{personal.name}</h3>
             <p className="mb-6 max-w-md text-muted">
-              Differential testing for critical protocol and cryptographic implementations — finding
-              cross-implementation failures before they become production incidents.
+              Security engineer at the Ethereum Foundation. I test systems where independent
+              implementations must agree.
             </p>
             <div className="flex space-x-5">
               <a

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -88,7 +88,7 @@ export default function Footer() {
               </li>
               <li>
                 <a
-                  href="/media/Bhargava_Shastry_CV.pdf"
+                  href={personal.cv}
                   target="_blank"
                   rel="noopener noreferrer"
                   className="text-muted transition-colors hover:text-fg"

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -18,7 +18,7 @@ const navigation: NavItem[] = [
   { name: 'Research', href: '#research', id: 'research' },
   { name: 'Findings', href: '#findings', id: 'findings' },
   { name: 'Talks', href: '#talks', id: 'talks' },
-  { name: 'Pubs', href: '#publications', id: 'publications' },
+  { name: 'Papers', href: '#publications', id: 'publications' },
   { name: 'Blog', href: '/blog' },
   { name: 'Work', href: '#contact', id: 'contact' },
 ]

--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -1,5 +1,5 @@
 import Link from 'next/link'
-import { ArrowDown, Sparkles } from 'lucide-react'
+import { ArrowDown, FileText } from 'lucide-react'
 import type { BlogPostMeta } from '@/lib/blog'
 import { formatDate } from '@/lib/format'
 
@@ -101,14 +101,19 @@ function MethodTrace() {
 
 export default function Hero({ latestPost, findingsCount, publicationsCount }: HeroProps) {
   const stats = [
-    { value: '10+', label: 'years in security', href: '#about' },
     {
-      value: '300+',
-      label: 'compiler commits',
-      href: 'https://github.com/ethereum/solidity/commits?author=bshastry',
+      value: String(findingsCount),
+      label: 'public findings · 2025–26',
+      href: '#findings',
+    },
+    {
+      value: '1',
+      label: 'security advisory',
+      href: 'https://mbed-tls.readthedocs.io/en/latest/security-advisories/mbedtls-security-advisory-2026-07-ecc-optimized-modp-side-channel/',
       external: true,
     },
-    { value: String(findingsCount), label: 'public findings', href: '#findings' },
+    // geth, Besu, Nethermind, Erigon, and revm — see caseStudies[0].approach.
+    { value: '5', label: 'EVM implementations cross-checked', href: '#case-studies' },
     { value: String(publicationsCount), label: 'publications', href: '#publications' },
   ]
 
@@ -122,40 +127,45 @@ export default function Hero({ latestPost, findingsCount, publicationsCount }: H
       <div className="container-max section-padding w-full py-16 sm:py-20 lg:py-24">
         <div className="grid items-center gap-12 lg:grid-cols-[minmax(0,1.12fr)_minmax(20rem,0.88fr)] lg:gap-16">
           <div className="min-w-0 animate-fade-in">
-            <p className="eyebrow flex items-center gap-3 text-accent">
+            <p className="eyebrow flex items-center gap-3 text-muted">
               <span aria-hidden="true" className="h-1.5 w-1.5 rounded-full bg-accent" />
-              Protocol security · differential testing
+              Security Engineer · Ethereum Foundation
             </p>
 
-            <h1 className="mt-6 text-[clamp(3.75rem,8vw,6.75rem)] font-semibold leading-[0.88] tracking-[-0.055em] text-fg">
-              <span className="block">Bhargava</span>
-              <span className="block text-accent">Shastry</span>
+            <h1 className="mt-5 whitespace-nowrap text-[clamp(2.25rem,10.8vw,2.55rem)] font-semibold leading-none tracking-[-0.045em] text-fg sm:text-5xl md:text-7xl">
+              Bhargava <span className="text-accent">Shastry</span>
             </h1>
 
-            <p className="mt-8 max-w-2xl text-xl leading-relaxed text-muted sm:text-2xl">
-              I find <span className="font-medium text-accent">cross-implementation failures</span>{' '}
-              before they become production incidents — turning disagreement between Ethereum
-              clients, cryptographic libraries, and compilers into reproducible evidence.
+            <p className="mt-7 max-w-2xl text-xl leading-relaxed text-fg sm:text-2xl">
+              I run independent implementations against each other — Ethereum clients, post-quantum
+              cryptography libraries, compilers — and turn every disagreement into a reproducible
+              bug report.
             </p>
 
-            <p className="mt-6 max-w-xl text-sm leading-relaxed text-faint">
-              Security Engineer at the Ethereum Foundation. Beyond the day job, I design AI-driven
-              triage and vulnerability-discovery pipelines with auditable logs and human review at
-              the decision points.
-            </p>
-
-            <div className="mt-8 flex flex-col items-start gap-3 sm:flex-row">
-              <a href="#case-studies" className="btn-primary px-6 py-3">
-                See case studies
+            <p className="mt-6 max-w-2xl text-sm leading-relaxed text-muted sm:text-base">
+              Recently: a confirmed-exploitable timing channel in Mbed TLS (
+              <a
+                href="https://mbed-tls.readthedocs.io/en/latest/security-advisories/mbedtls-security-advisory-2026-07-ecc-optimized-modp-side-channel/"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="link-accent"
+              >
+                security advisory, Jul 2026
               </a>
-              <a href="#contact" className="btn-ghost px-6 py-3">
-                Discuss a scoped review
+              ), upstream fixes merged in Erigon, Nethermind, and revm (
+              <a href="#findings" className="link-accent">
+                findings
               </a>
-            </div>
-
-            <p className="mt-5 max-w-xl text-xs leading-relaxed text-faint">
-              Independent engagements are limited and subject to conflict review. Employer
-              affiliation does not imply endorsement.
+              ), and 25 miscompilation bugs found in the Solidity compiler (
+              <a
+                href="https://arxiv.org/abs/2607.07217"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="link-accent"
+              >
+                paper
+              </a>
+              ).
             </p>
 
             {latestPost && (
@@ -163,7 +173,7 @@ export default function Hero({ latestPost, findingsCount, publicationsCount }: H
                 href={`/blog/${latestPost.slug}`}
                 className="focus-ring group mt-8 inline-flex max-w-full items-center gap-2 rounded-full border border-line bg-surface/60 px-4 py-2 text-sm text-muted transition-colors hover:border-line-strong hover:text-fg"
               >
-                <Sparkles size={14} className="flex-shrink-0 text-accent" />
+                <FileText size={14} className="flex-shrink-0 text-accent" />
                 <span className="eyebrow flex-shrink-0">Latest</span>
                 <span className="truncate">{latestPost.title}</span>
                 <time
@@ -208,6 +218,20 @@ export default function Hero({ latestPost, findingsCount, publicationsCount }: H
               <span className="eyebrow text-center">{stat.label}</span>
             </a>
           ))}
+        </div>
+
+        <div className="mt-8 flex flex-col items-start gap-3 sm:flex-row">
+          <a href="#case-studies" className="btn-primary px-6 py-3">
+            See case studies
+          </a>
+          <a
+            href="/media/Bhargava_Shastry_CV.pdf"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="btn-ghost px-6 py-3"
+          >
+            Download CV (PDF)
+          </a>
         </div>
 
         <a

--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -2,6 +2,7 @@ import Link from 'next/link'
 import { ArrowDown, FileText } from 'lucide-react'
 import type { BlogPostMeta } from '@/lib/blog'
 import { formatDate } from '@/lib/format'
+import portfolioData from '@/data/portfolio.json'
 
 type LatestPost = Pick<BlogPostMeta, 'slug' | 'title' | 'date'>
 
@@ -99,18 +100,28 @@ function MethodTrace() {
   )
 }
 
+// Derived from the findings ledger so the hero can't drift from the evidence
+// it links to: the advisory count/URL and the year range track portfolio.json.
+const advisories = portfolioData.findings.filter((f) => f.type === 'Security advisory')
+const advisoryUrl = advisories[0]?.url ?? '#findings'
+const findingYears = portfolioData.findings.map((f) => Number(f.date.slice(-4)))
+const oldestYear = Math.min(...findingYears)
+const newestYear = Math.max(...findingYears)
+const findingsRange =
+  oldestYear === newestYear ? String(oldestYear) : `${oldestYear}–${String(newestYear).slice(-2)}`
+
 export default function Hero({ latestPost, findingsCount, publicationsCount }: HeroProps) {
   const stats = [
     {
       value: String(findingsCount),
-      label: 'public findings · 2025–26',
+      label: `public findings · ${findingsRange}`,
       href: '#findings',
     },
     {
-      value: '1',
-      label: 'security advisory',
-      href: 'https://mbed-tls.readthedocs.io/en/latest/security-advisories/mbedtls-security-advisory-2026-07-ecc-optimized-modp-side-channel/',
-      external: true,
+      value: String(advisories.length),
+      label: advisories.length === 1 ? 'security advisory' : 'security advisories',
+      href: advisoryUrl,
+      external: advisories.length > 0,
     },
     // geth, Besu, Nethermind, Erigon, and revm — see caseStudies[0].approach.
     { value: '5', label: 'EVM implementations cross-checked', href: '#case-studies' },
@@ -145,7 +156,7 @@ export default function Hero({ latestPost, findingsCount, publicationsCount }: H
             <p className="mt-6 max-w-2xl text-sm leading-relaxed text-muted sm:text-base">
               Recently: a confirmed-exploitable timing channel in Mbed TLS (
               <a
-                href="https://mbed-tls.readthedocs.io/en/latest/security-advisories/mbedtls-security-advisory-2026-07-ecc-optimized-modp-side-channel/"
+                href={advisoryUrl}
                 target="_blank"
                 rel="noopener noreferrer"
                 className="link-accent"
@@ -225,7 +236,7 @@ export default function Hero({ latestPost, findingsCount, publicationsCount }: H
             See case studies
           </a>
           <a
-            href="/media/Bhargava_Shastry_CV.pdf"
+            href={portfolioData.personal.cv}
             target="_blank"
             rel="noopener noreferrer"
             className="btn-ghost px-6 py-3"

--- a/components/Publications.tsx
+++ b/components/Publications.tsx
@@ -1,4 +1,4 @@
-import { Award, BookOpen } from 'lucide-react'
+import { Award } from 'lucide-react'
 import portfolioData from '@/data/portfolio.json'
 
 export default function Publications() {
@@ -12,31 +12,25 @@ export default function Publications() {
           <p className="eyebrow mb-3">07 — Publications</p>
           <h2 className="section-title">Publications</h2>
           <p className="mt-4 max-w-2xl text-lg text-muted">
-            Peer-reviewed research in security, fuzzing, and program analysis
+            Research in security, fuzzing, and program analysis
           </p>
         </div>
 
-        <div className="mx-auto max-w-4xl space-y-12">
+        <div className="mx-auto max-w-4xl space-y-10">
           {nonEmpty.map((group) => (
             <div key={group.era}>
-              <h3 className="mb-4 flex items-center text-xl font-semibold text-fg">
-                <BookOpen size={20} className="mr-2 text-faint" />
-                {group.era}
-              </h3>
-              <div className="space-y-4">
+              <h3 className="mb-4 text-xl font-semibold text-fg">{group.era}</h3>
+              <div className="border-t border-line">
                 {group.papers.map((paper, i) => (
-                  <div
-                    key={i}
-                    className="rounded-lg border border-line p-4 transition-colors hover:border-line-strong"
-                  >
-                    <div className="flex items-start justify-between">
-                      <div className="flex-1">
+                  <article key={i} className="border-b border-line py-5">
+                    <div className="flex items-start justify-between gap-4">
+                      <div className="min-w-0 flex-1">
                         {paper.url ? (
                           <a
                             href={paper.url}
                             target="_blank"
                             rel="noopener noreferrer"
-                            className="font-medium text-fg hover:text-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+                            className="font-medium text-fg transition-colors hover:text-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
                           >
                             {paper.title}
                           </a>
@@ -53,7 +47,7 @@ export default function Publications() {
                         </span>
                       )}
                     </div>
-                  </div>
+                  </article>
                 ))}
               </div>
             </div>

--- a/components/Talks.tsx
+++ b/components/Talks.tsx
@@ -1,8 +1,13 @@
-import { FileText, Video, MapPin, Calendar } from 'lucide-react'
+import { Fragment } from 'react'
+import Link from 'next/link'
+import { BookOpen, FileText, Video } from 'lucide-react'
 import portfolioData from '@/data/portfolio.json'
 
+const latestVenueYear = (talk: (typeof portfolioData.talks)[number]) =>
+  Math.max(...talk.venues.map((venue) => venue.year))
+
 export default function Talks() {
-  const talks = [...portfolioData.talks].sort((a, b) => b.year - a.year)
+  const talks = [...portfolioData.talks].sort((a, b) => latestVenueYear(b) - latestVenueYear(a))
 
   return (
     <section id="talks" className="py-24 md:py-28">
@@ -17,59 +22,54 @@ export default function Talks() {
         </div>
 
         <div className="border-t border-line">
-          {talks.map((talk, i) => (
-            <div
-              key={i}
-              className="flex flex-col gap-4 border-b border-line py-6 md:flex-row md:items-start md:justify-between"
-            >
-              <div className="min-w-0">
-                <h3 className="text-lg font-semibold text-fg">{talk.title}</h3>
+          {talks.map((talk) => (
+            <article key={talk.title} className="border-b border-line py-6">
+              <h3 className="text-lg font-semibold text-fg">{talk.title}</h3>
 
-                {talk.summary && (
-                  <p className="mt-2 max-w-3xl text-sm leading-relaxed text-muted">
-                    {talk.summary}
-                  </p>
-                )}
+              {talk.summary && (
+                <p className="mt-2 max-w-3xl text-sm leading-relaxed text-muted">{talk.summary}</p>
+              )}
 
-                <div className="mt-2 flex flex-wrap items-center gap-x-4 gap-y-1.5 text-sm text-faint">
-                  <span className="flex items-center">
-                    <Calendar size={14} className="mr-2 flex-shrink-0" />
-                    {talk.venue}, {talk.year}
-                  </span>
-                  {talk.location && (
-                    <span className="flex items-center">
-                      <MapPin size={14} className="mr-2 flex-shrink-0" />
-                      {talk.location}
-                    </span>
-                  )}
-                </div>
-              </div>
+              <div className="mt-4 flex flex-wrap items-center gap-2">
+                {talk.venues.map((venue) => (
+                  <Fragment key={`${talk.title}-${venue.venue}`}>
+                    <a
+                      href={venue.slides}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      title={venue.location ? `${venue.venue}, ${venue.location}` : venue.venue}
+                      className="chip gap-1.5 hover:text-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+                    >
+                      <FileText size={13} />
+                      <span>
+                        {venue.venue} &apos;{String(venue.year).slice(-2)}
+                      </span>
+                    </a>
+                    {'video' in venue && venue.video && (
+                      <a
+                        href={venue.video}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="chip gap-1.5 hover:text-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+                      >
+                        <Video size={13} />
+                        <span>{venue.venue} video</span>
+                      </a>
+                    )}
+                  </Fragment>
+                ))}
 
-              <div className="flex flex-shrink-0 items-center gap-3">
-                {talk.slides && (
-                  <a
-                    href={talk.slides}
-                    target="_blank"
-                    rel="noopener noreferrer"
+                {'essay' in talk && talk.essay && (
+                  <Link
+                    href={talk.essay}
                     className="chip gap-1.5 hover:text-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
                   >
-                    <FileText size={14} />
-                    <span>Slides</span>
-                  </a>
-                )}
-                {talk.video && (
-                  <a
-                    href={talk.video}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="chip gap-1.5 hover:text-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
-                  >
-                    <Video size={14} />
-                    <span>Video</span>
-                  </a>
+                    <BookOpen size={13} />
+                    <span>Long version</span>
+                  </Link>
                 )}
               </div>
-            </div>
+            </article>
           ))}
         </div>
       </div>

--- a/components/Talks.tsx
+++ b/components/Talks.tsx
@@ -32,12 +32,15 @@ export default function Talks() {
 
               <div className="mt-4 flex flex-wrap items-center gap-2">
                 {talk.venues.map((venue) => (
-                  <Fragment key={`${talk.title}-${venue.venue}`}>
+                  <Fragment key={`${talk.title}-${venue.venue}-${venue.year}`}>
                     <a
                       href={venue.slides}
                       target="_blank"
                       rel="noopener noreferrer"
                       title={venue.location ? `${venue.venue}, ${venue.location}` : venue.venue}
+                      aria-label={`${venue.venue} ${venue.year} slides${
+                        venue.location ? `, ${venue.location}` : ''
+                      }`}
                       className="chip gap-1.5 hover:text-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
                     >
                       <FileText size={13} />

--- a/content/posts/trust-no-single-witness.md
+++ b/content/posts/trust-no-single-witness.md
@@ -1,0 +1,107 @@
+---
+title: "Trust No Single Witness"
+date: 2026-07-20
+excerpt: "In a system with more than one implementation there is no ground truth available to the test harness — only witnesses that can disagree. That changes how I test Ethereum clients, cryptographic libraries, compilers, and AI-assisted security pipelines."
+tags: ["differential-testing", "fuzzing", "ethereum", "cryptography", "verification", "oracle-problem"]
+---
+
+**In a system with more than one implementation there is no ground truth — only
+witnesses that disagree. So: trust no single witness.**
+
+That is the shortest version of my testing philosophy. It does not mean that a
+protocol has no specification or that every answer is subjective. It means a
+test harness cannot observe truth directly. Prose can be misread. An executable
+specification can contain a bug. A reference implementation can preserve
+behavior nobody intended. A test suite can share the system's wrong assumption.
+These sources are useful, but they do not become infallible because the test
+runner gives one of them a privileged name.
+
+The practical move is to make the witnesses disagree under controlled
+conditions. Generate one valid input, give it to implementations that reached
+the same contract by different routes, and compare the observable results. When
+one breaks from the others, minimize the input until the disagreement is small
+enough to understand, reproduce, and report. Differential testing does not tell
+you which implementation is right. It gives you a concrete case for
+investigation.
+
+## Agreement is evidence, not proof
+
+The corollary is that [a green checkmark is an agreed-upon
+guess](/blog/testing-oracles). A passing test says that the system and its oracle
+agree. It does not say that either is correct.
+
+Agreement can be correlated. Two clients may interpret the same ambiguous
+sentence alike. A compiler and its tests may inherit the same assumption. A
+model generating an answer and a model grading it may reproduce the same blind
+spot. Adding witnesses helps only when their failure modes are independent. The
+engineering work is therefore to construct that independence: different
+codebases, languages, teams, derivations, and oracles. A reference
+implementation, a property, an executable specification, and a human reviewer
+are all imperfect; together they are powerful when their imperfections do not
+line up.
+
+## Ethereum: consensus makes disagreement concrete
+
+Ethereum execution clients independently implement the same state-transition
+rules and must agree on every block. In my [cross-client case
+study](/#case-studies), state tests run across geth, Besu, Nethermind, Erigon,
+and revm without appointing one implementation as the unquestionable oracle. A
+different BLOCKHASH at genesis, an account touched on a failed transaction, or
+an overflow in memory-size computation becomes visible as a split among
+witnesses. Executable specifications add another witness near hard forks. The
+useful output is the minimized test that explains the split, supports an
+upstream fix, and prevents the divergence from returning.
+
+## Post-quantum cryptography: standards need independent readers
+
+ML-KEM and ML-DSA implementations can be individually well tested and still
+disagree on an edge case, encoding, or boundary condition. The [ML-KEM
+differential-testing series](/blog/cross-checking-post-quantum-kem) co-links
+independent libraries and drives them with the same generated inputs.
+Functional equivalence is one oracle; constant-time behavior is another. The
+result also names the blind spots: which paths the harness reaches, which it
+does not, and what a clean run therefore cannot establish.
+
+## Compilers: the program is its own experiment
+
+Compiler correctness rarely has an easy expected output. A semantics-aware
+generator can instead produce valid programs and ask independent execution
+paths whether transformations preserved behavior. [SolSmith](https://arxiv.org/abs/2607.07217)
+used that approach to surface 25 miscompilation bugs in the Solidity compiler,
+including bugs that had remained unnoticed for years. The method is the deeper
+result: generate valid inputs, compare witnesses at the semantic boundary, then
+reduce each divergence until its root cause can be explained.
+
+## AI-assisted security: scale the witnesses, preserve the judgment
+
+AI systems make it cheap to create more hypotheses, harnesses, and attempted
+proofs of concept. They do not remove the oracle problem; they make it easier to
+manufacture confident agreement.
+
+The [three-witness severity model](/media/Trust_No_Single_Witness.pdf) I use for
+AI-era bug-bounty triage separates the reporter's claim, an AI-assisted attempt
+to validate it, and the network blast radius. The pipeline keeps auditable logs
+and human review at the decision points because speed is not authority. An agent
+can gather context, propose a harness, and try to reproduce an impact. A person
+still has to decide what the evidence supports.
+
+LLM-as-judge evaluations deserve the same suspicion. Generator and judge may be
+different processes while remaining correlated witnesses. A higher score can
+mean a better answer, or merely an answer that fits the judge's preferences and
+blind spots. Useful evaluation introduces different failure modes deliberately:
+executable checks where possible, properties, models from different lineages,
+adversarial cases, and human review of disagreements.
+
+## What the method predicts
+
+As systems become harder to specify completely, testing will look less like
+consulting one oracle and more like managing a panel of fallible witnesses. The
+best harnesses will expose each witness's provenance, record the evidence behind
+decisions, and treat unanimity as a reason to ask what the panel shares.
+
+AI can scale that panel, but it cannot turn the panel into ground truth. The job
+is to engineer independent ways of being wrong, force them into productive
+disagreement, and preserve the path from divergence to reproducible evidence.
+
+Trust no single witness. Make the witnesses disagree, then learn from the shape
+of the disagreement.

--- a/content/posts/trust-no-single-witness.md
+++ b/content/posts/trust-no-single-witness.md
@@ -2,7 +2,8 @@
 title: "Trust No Single Witness"
 date: 2026-07-20
 excerpt: "In a system with more than one implementation there is no ground truth available to the test harness — only witnesses that can disagree. That changes how I test Ethereum clients, cryptographic libraries, compilers, and AI-assisted security pipelines."
-tags: ["differential-testing", "fuzzing", "ethereum", "cryptography", "verification", "oracle-problem"]
+tags: ["differential-testing", "fuzzing", "oracle-problem", "verification"]
+pinned: true
 ---
 
 **In a system with more than one implementation there is no ground truth — only

--- a/data/portfolio.json
+++ b/data/portfolio.json
@@ -2,7 +2,7 @@
   "personal": {
     "name": "Bhargava Shastry",
     "title": "Security Engineer & Researcher",
-    "description": "I find cross-implementation failures before they become production incidents — differential testing of Ethereum clients, cryptographic libraries, and compilers, scaled by AI-driven triage and vulnerability-discovery pipelines I design and build.",
+    "description": "Security engineer at the Ethereum Foundation. Differential testing of Ethereum clients, post-quantum cryptography, and compilers — plus the AI-assisted triage pipelines that scale it.",
     "location": "Remote",
     "email": "bshastry@posteo.de",
     "social": {
@@ -18,25 +18,25 @@
       "title": "Security Engineer",
       "company": "Ethereum Foundation",
       "period": "2019 - Present",
-      "description": "Protocol security for Ethereum: differential fuzzing of execution clients, hard-fork readiness testing, and technical evaluation of bug bounty submissions across execution- and consensus-layer clients."
+      "description": "Differential fuzzing, hard-fork readiness, and bug-bounty triage across Ethereum clients."
     },
     {
       "title": "Independent Security Researcher",
       "company": "Freelance",
       "period": "2017 - Present",
-      "description": "Independent security research, building fuzzing tools, and contributing to open-source security projects including Google's OSS-Fuzz and Open vSwitch."
+      "description": "Open-source security research, fuzzing tools, and contributions to OSS-Fuzz and Open vSwitch."
     },
     {
       "title": "Security Researcher",
       "company": "Fraunhofer Secure IT",
       "period": "2011 - 2012",
-      "description": "Research on Android platform security, including privilege escalation defenses and lightweight domain isolation. Published at NDSS and ACM SPSM."
+      "description": "Android platform security research; published at NDSS and ACM SPSM."
     },
     {
       "title": "Software Engineer",
       "company": "Ittiam Systems",
       "period": "2007 - 2008",
-      "description": "Wrote software and tests for Ittiam's Voice over IP phone software."
+      "description": "VoIP phone software and tests."
     }
   ],
   "education": [
@@ -339,7 +339,17 @@
       "project": "Mbed-TLS/mbedtls",
       "type": "Security advisory",
       "date": "Jul 2026",
-      "url": "https://mbed-tls.readthedocs.io/en/latest/security-advisories/mbedtls-security-advisory-2026-07-ecc-optimized-modp-side-channel/"
+      "url": "https://mbed-tls.readthedocs.io/en/latest/security-advisories/mbedtls-security-advisory-2026-07-ecc-optimized-modp-side-channel/",
+      "featured": true
+    },
+    {
+      "title": "25 miscompilation bugs in the Solidity compiler",
+      "description": "SolSmith, a semantics-aware differential fuzzer, surfaced miscompilation bugs that had gone unnoticed — some for years — with a root-cause analysis of each.",
+      "project": "ethereum/solidity",
+      "type": "Paper",
+      "date": "Jul 2026",
+      "url": "https://arxiv.org/abs/2607.07217",
+      "featured": true
     },
     {
       "title": "Variable-time division on Mbed TLS RSA prime-generation path",
@@ -348,14 +358,6 @@
       "type": "Fixed upstream",
       "date": "Jul 2026",
       "url": "https://github.com/Mbed-TLS/TF-PSA-Crypto/blob/development/ChangeLog"
-    },
-    {
-      "title": "25 miscompilation bugs in the Solidity compiler",
-      "description": "SolSmith, a semantics-aware differential fuzzer, surfaced miscompilation bugs that had gone unnoticed — some for years — with a root-cause analysis of each.",
-      "project": "ethereum/solidity",
-      "type": "Paper",
-      "date": "Jul 2026",
-      "url": "https://arxiv.org/abs/2607.07217"
     },
     {
       "title": "Hard-fork readiness tests upstreamed to the executable spec",
@@ -417,59 +419,74 @@
   "talks": [
     {
       "title": "Trust No Single Witness: Differential Fuzzing & Bug-Bounty Triage for Ethereum Clients",
-      "venue": "Berlin Ethereum Day",
-      "location": "Berlin",
-      "year": 2026,
-      "slides": "/media/Trust_No_Single_Witness.pdf",
-      "summary": "There is no ground truth in Ethereum — only witnesses that disagree. How differential fuzzing across ~8 execution clients catches consensus splits within hours of a commit, how LLM property-based testing attacks the blind spots all clients share, and how a three-witness severity model (reporter, AI swarm, network blast radius) keeps AI-era bounty triage honest. Takeaway: a green checkmark is an agreed-upon guess."
+      "venues": [
+        {
+          "venue": "Berlin Ethereum Day",
+          "location": "Berlin",
+          "year": 2026,
+          "slides": "/media/Trust_No_Single_Witness.pdf"
+        }
+      ],
+      "essay": "/blog/trust-no-single-witness",
+      "summary": "How differential fuzzing across ~8 execution clients catches consensus splits within hours of a commit, how LLM property-based testing attacks shared blind spots, and how a three-witness severity model (reporter, AI swarm, network blast radius) keeps AI-era bounty triage honest."
     },
     {
       "title": "Fuzzing the Solidity Compiler",
-      "venue": "Devcon 5",
-      "location": "Osaka",
-      "year": 2019,
-      "slides": "/media/Fuzzing_Solidity.pdf",
-      "video": "https://youtu.be/cAU5NbrXst0",
-      "summary": "Threat model: incorrect code generation. Randomly generated valid Solidity/Yul programs stress the compiler's codegen and optimizer before releases ship."
-    },
-    {
-      "title": "Fuzzing the Solidity Compiler",
-      "venue": "EthCC 3",
-      "location": "Paris",
-      "year": 2020,
-      "slides": "/media/Fuzzing_Solidity_EthCC3.pdf",
-      "summary": "Updated iteration of the Devcon 5 talk: nine bugs found via semantic fuzzing of the compiler's code generation."
-    },
-    {
-      "title": "Fuzzing the Solidity Compiler",
-      "venue": "FuzzCon EU",
-      "location": "Europe",
-      "year": 2020,
-      "slides": "/media/Fuzzing_Solidity_FuzzconEU.pdf",
-      "summary": "The compiler-fuzzing pipeline presented to a fuzzing-practitioner audience: generating valid programs, differential oracles, and OSS-Fuzz integration."
+      "venues": [
+        {
+          "venue": "Devcon 5",
+          "location": "Osaka",
+          "year": 2019,
+          "slides": "/media/Fuzzing_Solidity.pdf",
+          "video": "https://youtu.be/cAU5NbrXst0"
+        },
+        {
+          "venue": "EthCC 3",
+          "location": "Paris",
+          "year": 2020,
+          "slides": "/media/Fuzzing_Solidity_EthCC3.pdf"
+        },
+        {
+          "venue": "FuzzCon EU",
+          "year": 2020,
+          "slides": "/media/Fuzzing_Solidity_FuzzconEU.pdf"
+        }
+      ],
+      "summary": "Threat model: incorrect code generation. Randomly generated valid Solidity/Yul programs stress the compiler's codegen and optimizer before releases ship — nine bugs found via semantic fuzzing."
     },
     {
       "title": "Can A Fuzzer Match A Human: Solidity Case Study",
-      "venue": "Ethereum Foundation",
-      "location": "",
-      "year": 2020,
-      "slides": "/media/Can_A_Fuzzer_Match_A_Human.pdf",
+      "venues": [
+        {
+          "venue": "Ethereum Foundation",
+          "year": 2020,
+          "slides": "/media/Can_A_Fuzzer_Match_A_Human.pdf"
+        }
+      ],
       "summary": "A fuzzer is no match for a human tester — but it finds security-critical bugs humans miss, and it shines at differential (A/B) testing."
     },
     {
       "title": "Open Discussion on Solidity Fuzzing",
-      "venue": "Ethereum Meetup",
-      "location": "Berlin",
-      "year": 2019,
-      "slides": "/media/Eth_Meetup_Slides.pdf",
+      "venues": [
+        {
+          "venue": "Ethereum Meetup",
+          "location": "Berlin",
+          "year": 2019,
+          "slides": "/media/Eth_Meetup_Slides.pdf"
+        }
+      ],
       "summary": "The state of Solidity compiler testing — unit, regression, and fuzz tests — and where community input could help."
     },
     {
       "title": "Vulnerability Search Problem and Methods",
-      "venue": "TU Berlin (Invited Talk)",
-      "location": "Berlin",
-      "year": 2019,
-      "slides": "/media/Vulnerability_Search_Problem_and_Methods.pdf",
+      "venues": [
+        {
+          "venue": "TU Berlin (Invited Talk)",
+          "location": "Berlin",
+          "year": 2019,
+          "slides": "/media/Vulnerability_Search_Problem_and_Methods.pdf"
+        }
+      ],
       "summary": "Why vulnerabilities are expensive, and how static analysis and fuzzing complement each other in finding them."
     }
   ],

--- a/data/portfolio.json
+++ b/data/portfolio.json
@@ -5,6 +5,7 @@
     "description": "Security engineer at the Ethereum Foundation. Differential testing of Ethereum clients, post-quantum cryptography, and compilers — plus the AI-assisted triage pipelines that scale it.",
     "location": "Remote",
     "email": "bshastry@posteo.de",
+    "cv": "/media/Bhargava_Shastry_CV.pdf",
     "social": {
       "github": "bshastry",
       "twitter": "ibags",

--- a/lib/blog.ts
+++ b/lib/blog.ts
@@ -38,6 +38,8 @@ export interface BlogPostMeta {
   excerpt: string
   tags: string[]
   readTime: string
+  /** Pins the post to the top of the blog index with a "Start here" badge. */
+  pinned?: boolean
   series?: SeriesInfo
 }
 
@@ -56,6 +58,7 @@ interface PostFrontmatter {
   date: string | Date
   excerpt: string
   tags: string[]
+  pinned?: boolean
   seriesId?: string
   series?: string
   seriesPart?: number
@@ -126,6 +129,7 @@ export function getAllPostsMeta(): BlogPostMeta[] {
         excerpt: frontmatter.excerpt,
         tags: frontmatter.tags ?? [],
         readTime: computeReadTime(body),
+        pinned: frontmatter.pinned === true || undefined,
         series: parseSeries(frontmatter, slug),
       }
     })

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -36,15 +36,7 @@ module.exports = {
       },
       fontFamily: {
         sans: ['var(--font-inter)', 'system-ui', 'sans-serif'],
-        mono: [
-          'ui-monospace',
-          'SFMono-Regular',
-          'Cascadia Code',
-          'Roboto Mono',
-          'Menlo',
-          'Consolas',
-          'monospace',
-        ],
+        mono: ['var(--font-jetbrains-mono)', 'monospace'],
       },
       animation: {
         'fade-in': 'fadeIn 0.5s ease-in-out',


### PR DESCRIPTION
Applies the validated site-improvement patch, implementing the reviewed plan end to end (employability-first, credibility as the hard constraint):

## Changes

- **Hero (Phases 1–2):** role eyebrow "Security Engineer · Ethereum Foundation" at visible weight, one-line name, ≤30-word claim, evidence-linked proof line (Mbed TLS advisory · merged fixes in Erigon/Nethermind/revm · SolSmith paper), recency-focused stats row (`10 public findings · 2025–26`, `1 security advisory`, `5 EVM implementations cross-checked`, `11 publications`), CV as secondary CTA. Consulting CTA and the duplicate disclaimer removed from the hero.
- **About (Phase 3):** thesis pull-quote ("trust no single witness") linking the new canonical essay, tightened prose with no hero overlap, and a new **Experience / Education timeline** rendered from `portfolio.json` — previously this data was never rendered anywhere. CV button moved directly under the timeline.
- **Work with me (Phase 4):** open-door intro (roles, collaboration, talks, podcasts) with email/LinkedIn/CV links first; upstream-merge referenceability line; engagements demoted to a clearly labeled "Independent engagements — limited" sub-block with audience + "You get:" deliverables per card and a 4-step process strip (conflict check as step 2). No durations/availability invented — owner fills those in later.
- **Congruence (Phase 5):** JetBrains Mono self-hosted via `next/font` (zero third-party font requests, verified in build output); Case Studies "Demonstrates" punchline promoted to a legible line; nav "Pubs" → "Papers"; footer brand sentence deduplicated.
- **Evidence presentation (Phase 6):** featured tier in Findings (advisory + SolSmith paper as full-width accent rows); Talks merged per-title with venue chips (5 rows, no duplicate titles, every deck still reachable); Publications flattened to a citation list with era groups and award chip preserved.
- **POV consolidation (Phase 7):** new pinned essay `content/posts/trust-no-single-witness.md` as the canonical statement, "Start here" pin on the blog index, cross-links from About and the flagship talk entry.

## Validation

- `npm run check` (typecheck + lint + format) and `npm run build` (static export, 67 routes incl. the new essay) pass.
- Internal-link audit: every homepage/media/blog target resolves in `out/`.
- Chromium screenshots at 375 / 768 / 1280 px in light + dark: no horizontal overflow, no console errors; hero shows role + employer in the first 375 px viewport.
- Zero requests to fonts.googleapis.com / fonts.gstatic.com (the `@import` was already removed upstream; mono now self-hosted too).

Owner follow-ups (intentionally not fabricated): refresh `public/media/Bhargava_Shastry_CV.pdf` for 2026, and add real engagement durations/availability if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ULGoEaAAjb3Zc3TfTPouaG

---
_Generated by [Claude Code](https://claude.ai/code/session_01ULGoEaAAjb3Zc3TfTPouaG)_