### PR TITLE
Proof-first homepage, portable brand positioning, 404 page, security.txt, CI link-audit gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,3 +18,4 @@ jobs:
       - run: npm run lint
       - run: npm run format:check
       - run: npm run build
+      - run: npm run check:links

--- a/.gitignore
+++ b/.gitignore
@@ -77,7 +77,10 @@ temp/
 # Claude Code memory
 memory-bank/
 legacy-archive/
-scripts/
+# Ignore scratch scripts but keep the CI link-audit gate tracked
+# (a bare `scripts/` would make the file impossible to re-include).
+scripts/*
+!scripts/check-links.mjs
 
 # Local research / drafts not intended for publication
 private/

--- a/README.md
+++ b/README.md
@@ -24,16 +24,17 @@ Open [http://localhost:3000](http://localhost:3000). The dev server hot-reloads 
 
 ## Scripts
 
-| Command                | Purpose                         |
-| ---------------------- | ------------------------------- |
-| `npm run dev`          | Local dev server with HMR       |
-| `npm run build`        | Static export to `out/`         |
-| `npm run typecheck`    | `tsc --noEmit`                  |
-| `npm run lint`         | ESLint (`next/core-web-vitals`) |
-| `npm run lint:fix`     | ESLint with `--fix`             |
-| `npm run format`       | Prettier write                  |
-| `npm run format:check` | Prettier check (used in CI)     |
-| `npm run check`        | typecheck + lint + format:check |
+| Command                | Purpose                                                         |
+| ---------------------- | --------------------------------------------------------------- |
+| `npm run dev`          | Local dev server with HMR                                       |
+| `npm run build`        | Static export to `out/`                                         |
+| `npm run typecheck`    | `tsc --noEmit`                                                  |
+| `npm run lint`         | ESLint (`next/core-web-vitals`)                                 |
+| `npm run lint:fix`     | ESLint with `--fix`                                             |
+| `npm run format`       | Prettier write                                                  |
+| `npm run format:check` | Prettier check (used in CI)                                     |
+| `npm run check`        | typecheck + lint + format:check                                 |
+| `npm run check:links`  | Internal-link audit over `out/` (run after `build`; used in CI) |
 
 ## Writing a blog post
 
@@ -57,6 +58,7 @@ Open [http://localhost:3000](http://localhost:3000). The dev server hot-reloads 
 app/
   layout.tsx              Root layout + metadata + fonts
   page.tsx                Server-rendered homepage (composes components)
+  not-found.tsx           Branded 404 with routes back into the evidence pages
   blog/
     page.tsx              Blog index (server component)
     BlogIndexClient.tsx   Client-side search/filter
@@ -90,14 +92,18 @@ data/
 
 public/
   llms.txt                Curated agent-readable site index
+  .well-known/security.txt  RFC 9116 vulnerability-report contact (has an Expires date — renew yearly)
   <year>/.../*.html       Legacy Jekyll article redirects
+
+scripts/
+  check-links.mjs         CI gate: fails the build on broken internal links in out/
 ```
 
 ## Deployment
 
 Hosted at [bshastry.github.io](https://bshastry.github.io). Deployment is automated via GitHub Actions:
 
-- **`.github/workflows/ci.yml`** runs on every push and PR to any branch. It runs `npm run check` and `npm run build` to catch regressions before merge.
+- **`.github/workflows/ci.yml`** runs on every push and PR to any branch. It runs `npm run check`, `npm run build`, and `npm run check:links` to catch regressions before merge.
 - **`.github/workflows/deploy.yml`** runs only on push to `master`. It builds the static site and publishes `out/` to GitHub Pages.
 
 ### Repo-level settings (one-time)

--- a/app/blog/[slug]/opengraph-image.tsx
+++ b/app/blog/[slug]/opengraph-image.tsx
@@ -24,6 +24,8 @@ export default async function OGImage({ params }: { params: Promise<{ slug: stri
   // Long titles get a smaller type size so they stay inside the canvas.
   const titleSize = title.length > 70 ? 52 : title.length > 45 ? 62 : 72
 
+  // Visual language matches the homepage OG card (app/opengraph-image.tsx):
+  // near-black canvas, accent radial glow, accent eyebrow, footer rule.
   return new ImageResponse(
     <div
       style={{
@@ -33,18 +35,60 @@ export default async function OGImage({ params }: { params: Promise<{ slug: stri
         flexDirection: 'column',
         justifyContent: 'space-between',
         padding: '80px',
-        background: 'linear-gradient(135deg, #0f172a 0%, #1e293b 60%, #312e81 100%)',
-        color: 'white',
+        backgroundColor: '#0a0a0a',
+        backgroundImage:
+          'radial-gradient(circle at 82% 18%, rgba(59, 130, 246, 0.22), transparent 30%)',
+        color: '#ededed',
         fontFamily: 'sans-serif',
       }}
     >
       <div style={{ display: 'flex', flexDirection: 'column' }}>
-        <div style={{ fontSize: 28, opacity: 0.7, marginBottom: 40 }}>bshastry.github.io/blog</div>
-        <div style={{ fontSize: titleSize, fontWeight: 800, lineHeight: 1.1 }}>{title}</div>
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 14,
+            color: '#6ea8fe',
+            fontSize: 22,
+            letterSpacing: '0.18em',
+            textTransform: 'uppercase',
+            marginBottom: 40,
+          }}
+        >
+          <span
+            style={{
+              width: 9,
+              height: 9,
+              borderRadius: 999,
+              background: '#6ea8fe',
+            }}
+          />
+          Blog
+        </div>
+        <div
+          style={{
+            fontSize: titleSize,
+            fontWeight: 700,
+            lineHeight: 1.1,
+            letterSpacing: '-0.02em',
+          }}
+        >
+          {title}
+        </div>
       </div>
-      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
-        <div style={{ fontSize: 32, opacity: 0.92 }}>Bhargava Shastry</div>
-        <div style={{ fontSize: 28, opacity: 0.7 }}>{post ? formatDate(post.date) : ''}</div>
+      <div
+        style={{
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+          borderTop: '1px solid #242424',
+          paddingTop: 24,
+          color: '#777',
+          fontSize: 22,
+        }}
+      >
+        <span style={{ color: '#b8b8b8', fontSize: 26 }}>Bhargava Shastry</span>
+        <span>{post ? formatDate(post.date) : 'bshastry.github.io/blog'}</span>
       </div>
     </div>,
     { ...size },

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -20,7 +20,7 @@ const siteDescription = portfolioData.personal.description
 export const metadata: Metadata = {
   metadataBase: new URL('https://bshastry.github.io'),
   title: {
-    default: 'Bhargava Shastry — Security Engineer & Researcher',
+    default: 'Bhargava Shastry — Differential Testing & Protocol Security',
     template: '%s — Bhargava Shastry',
   },
   description: siteDescription,
@@ -29,6 +29,8 @@ export const metadata: Metadata = {
     'differential fuzzing',
     'ethereum',
     'protocol security',
+    'implementation security',
+    'compiler security',
     'post-quantum cryptography',
     'AI-assisted vulnerability research',
     'bug bounty',
@@ -42,12 +44,12 @@ export const metadata: Metadata = {
     locale: 'en_US',
     url: 'https://bshastry.github.io',
     siteName: 'Bhargava Shastry',
-    title: 'Bhargava Shastry — Security Engineer & Researcher',
+    title: 'Bhargava Shastry — Differential Testing & Protocol Security',
     description: siteDescription,
   },
   twitter: {
     card: 'summary_large_image',
-    title: 'Bhargava Shastry — Security Engineer & Researcher',
+    title: 'Bhargava Shastry — Differential Testing & Protocol Security',
     description: siteDescription,
     creator: '@ibags',
   },

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -1,0 +1,81 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import { ArrowLeft, FileSearch, FlaskConical, Rss } from 'lucide-react'
+import ThemeToggle from '@/components/ThemeToggle'
+
+export const metadata: Metadata = {
+  title: 'Page Not Found',
+}
+
+// The Jekyll-era site lived at these URLs for years; the shims under public/
+// cover known posts, but decayed or mistyped inbound links still land here.
+const destinations = [
+  {
+    href: '/findings/',
+    icon: FileSearch,
+    title: 'Security findings & disclosures',
+    description: 'The complete CVE ledger, Solidity compiler bug records, and recent merged fixes.',
+  },
+  {
+    href: '/research/',
+    icon: FlaskConical,
+    title: 'Research archive',
+    description: 'Current and historical research themes, tools, and upstream work.',
+  },
+  {
+    href: '/blog/',
+    icon: Rss,
+    title: 'Blog',
+    description: 'Technical writing on fuzzing, protocol security, cryptography, and compilers.',
+  },
+]
+
+export default function NotFound() {
+  return (
+    <main id="main-content" className="flex min-h-screen flex-col bg-bg">
+      <div className="border-b border-line">
+        <div className="container-max section-padding flex items-center justify-between py-8">
+          <Link
+            href="/"
+            className="link-accent inline-flex items-center focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+          >
+            <ArrowLeft size={20} className="mr-2" aria-hidden="true" />
+            Back to the portfolio
+          </Link>
+          <ThemeToggle />
+        </div>
+      </div>
+
+      <div className="container-max section-padding flex flex-1 flex-col justify-center py-16 md:py-24">
+        <p className="eyebrow mb-3 text-accent">404 · no witness at this address</p>
+        <h1 className="section-title mb-5">Page not found</h1>
+        <p className="max-w-2xl text-xl leading-relaxed text-muted">
+          This URL doesn&apos;t resolve — likely an old link from the previous version of this site.
+          The evidence is still here; it just moved.
+        </p>
+
+        <div className="mt-12 grid max-w-4xl grid-cols-1 gap-6 md:grid-cols-3">
+          {destinations.map((item) => (
+            <Link
+              key={item.href}
+              href={item.href}
+              className="focus-ring group rounded-xl border border-line bg-surface/50 p-6 transition-colors hover:border-line-strong hover:bg-surface"
+            >
+              <item.icon size={20} className="mb-4 text-accent" aria-hidden="true" />
+              <h2 className="font-medium text-fg group-hover:text-accent">{item.title}</h2>
+              <p className="mt-2 text-sm leading-relaxed text-muted">{item.description}</p>
+            </Link>
+          ))}
+        </div>
+
+        <p className="mt-12 max-w-2xl text-sm leading-relaxed text-faint">
+          Looking for something specific that used to live here?{' '}
+          <a href="mailto:bshastry@posteo.de" className="link-accent">
+            Email me
+          </a>{' '}
+          and I&apos;ll point you to it.
+        </p>
+      </div>
+    </main>
+  )
+}

--- a/app/opengraph-image.tsx
+++ b/app/opengraph-image.tsx
@@ -6,7 +6,7 @@ export const dynamic = 'force-static'
 // causes `next build` to error. `next/og` works at build time in the
 // default Node runtime when the static export target is set.
 
-export const alt = 'Bhargava Shastry — Security Engineer & Researcher'
+export const alt = 'Bhargava Shastry — Differential Testing & Protocol Security'
 export const size = { width: 1200, height: 630 }
 export const contentType = 'image/png'
 
@@ -20,20 +20,81 @@ export default async function OGImage() {
         flexDirection: 'column',
         justifyContent: 'center',
         padding: '80px',
-        background: 'linear-gradient(135deg, #0f172a 0%, #1e293b 60%, #312e81 100%)',
-        color: 'white',
+        backgroundColor: '#0a0a0a',
+        backgroundImage:
+          'radial-gradient(circle at 82% 18%, rgba(59, 130, 246, 0.22), transparent 30%)',
+        color: '#ededed',
         fontFamily: 'sans-serif',
       }}
     >
-      <div style={{ fontSize: 28, opacity: 0.7, marginBottom: 24 }}>bshastry.github.io</div>
-      <div style={{ fontSize: 82, fontWeight: 800, lineHeight: 1.05, marginBottom: 24 }}>
-        Bhargava Shastry
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 14,
+          color: '#6ea8fe',
+          fontSize: 22,
+          letterSpacing: '0.18em',
+          textTransform: 'uppercase',
+          marginBottom: 32,
+        }}
+      >
+        <span
+          style={{
+            width: 9,
+            height: 9,
+            borderRadius: 999,
+            background: '#6ea8fe',
+          }}
+        />
+        Differential testing · critical systems
       </div>
-      <div style={{ fontSize: 42, opacity: 0.92, marginBottom: 12 }}>
-        Security Engineer &amp; Researcher
+      <div
+        style={{
+          display: 'flex',
+          fontSize: 84,
+          fontWeight: 700,
+          lineHeight: 1,
+          letterSpacing: '-0.04em',
+        }}
+      >
+        Bhargava <span style={{ color: '#6ea8fe', marginLeft: 18 }}>Shastry</span>
       </div>
-      <div style={{ fontSize: 28, opacity: 0.7, maxWidth: 900 }}>
-        Ethereum Foundation · Smart contract security · Fuzzing · Blockchain
+      <div
+        style={{ fontSize: 38, lineHeight: 1.25, color: '#b8b8b8', maxWidth: 930, marginTop: 34 }}
+      >
+        Turning disagreement between independent implementations into reproducible evidence.
+      </div>
+      <div style={{ display: 'flex', gap: 14, marginTop: 42 }}>
+        {['Ethereum clients', 'Cryptographic libraries', 'Compilers'].map((label) => (
+          <div
+            key={label}
+            style={{
+              display: 'flex',
+              border: '1px solid #2e2e2e',
+              borderRadius: 8,
+              padding: '10px 16px',
+              color: '#8a8a8a',
+              fontSize: 20,
+            }}
+          >
+            {label}
+          </div>
+        ))}
+      </div>
+      <div
+        style={{
+          display: 'flex',
+          justifyContent: 'space-between',
+          borderTop: '1px solid #242424',
+          paddingTop: 24,
+          marginTop: 42,
+          color: '#777',
+          fontSize: 19,
+        }}
+      >
+        <span>Security Engineer · Ethereum Foundation</span>
+        <span>bshastry.github.io</span>
       </div>
     </div>,
     { ...size },

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -27,16 +27,28 @@ const personJsonLd = {
     '@type': 'CollegeOrUniversity',
     name: 'Technische Universität Berlin',
   },
+  hasCredential: {
+    '@type': 'EducationalOccupationalCredential',
+    credentialCategory: 'degree',
+    educationalLevel: 'Ph.D.',
+    about: 'Static analysis and fuzzing techniques for open source bug detection',
+    recognizedBy: {
+      '@type': 'CollegeOrUniversity',
+      name: 'Technische Universität Berlin',
+    },
+  },
   sameAs: [
     'https://github.com/bshastry',
     'https://twitter.com/ibags',
     'https://linkedin.com/in/bshastry',
     'https://scholar.google.com/citations?hl=en&user=lsdZxf8AAAAJ',
+    'https://keybase.io/bshastry',
   ],
   knowsAbout: [
     'Differential testing',
     'Fuzzing',
     'Ethereum protocol security',
+    'Compiler security',
     'AI-assisted vulnerability research',
     'Post-quantum cryptography',
     'Side-channel analysis',

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -31,7 +31,10 @@ const personJsonLd = {
     '@type': 'EducationalOccupationalCredential',
     credentialCategory: 'degree',
     educationalLevel: 'Ph.D.',
-    about: 'Static analysis and fuzzing techniques for open source bug detection',
+    about: {
+      '@type': 'Thing',
+      name: 'Static analysis and fuzzing techniques for open source bug detection',
+    },
     recognizedBy: {
       '@type': 'CollegeOrUniversity',
       name: 'Technische Universität Berlin',

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -73,8 +73,8 @@ export default function Home() {
       <Header />
       <main id="main-content" className="min-h-screen">
         <Hero latestPost={latestPost} publicationsCount={publicationsCount} />
-        <About />
         <CaseStudies />
+        <About />
         <Projects />
         <Findings />
         <Talks />

--- a/components/About.tsx
+++ b/components/About.tsx
@@ -35,7 +35,7 @@ export default function About() {
     <section id="about" className="bg-bg py-24 md:py-28">
       <div className="container-max section-padding">
         <div className="mb-16">
-          <p className="eyebrow mb-4">01 — About</p>
+          <p className="eyebrow mb-4">02 — About</p>
           <h2 className="section-title">About Me</h2>
         </div>
 

--- a/components/CaseStudies.tsx
+++ b/components/CaseStudies.tsx
@@ -1,5 +1,6 @@
 import portfolioData from '@/data/portfolio.json'
 import { ThemeLink } from '@/components/ResearchGrid'
+import { ArrowRight } from 'lucide-react'
 
 export default function CaseStudies() {
   const { caseStudies } = portfolioData
@@ -8,7 +9,7 @@ export default function CaseStudies() {
     <section id="case-studies" className="border-t border-line bg-surface/30 py-24 md:py-28">
       <div className="container-max section-padding">
         <div className="mb-16">
-          <p className="eyebrow mb-4">02 — Case Studies</p>
+          <p className="eyebrow mb-4">01 — Case Studies</p>
           <h2 className="section-title">Case Studies</h2>
           <p className="mt-4 max-w-2xl text-lg text-muted">
             Three examples of what differential validation looks like in practice — what was at
@@ -60,13 +61,22 @@ export default function CaseStudies() {
           ))}
         </div>
 
-        <p className="mt-12 max-w-3xl text-sm leading-relaxed text-faint">
-          Working on a system where independent implementations must agree?{' '}
-          <a href="#contact" className="link-accent">
-            Discuss a scoped review
+        <div className="mt-12 flex flex-col items-start justify-between gap-6 border-t border-line pt-8 sm:flex-row sm:items-center">
+          <div>
+            <p className="eyebrow mb-2 text-accent">Where this fits</p>
+            <p className="max-w-2xl text-sm leading-relaxed text-muted">
+              Working on a critical system where independent implementations must agree — or
+              building the team that is?
+            </p>
+          </div>
+          <a
+            href="#contact"
+            className="btn-primary inline-flex flex-shrink-0 items-center gap-2 px-5 py-2.5"
+          >
+            <span>Start a conversation</span>
+            <ArrowRight size={15} aria-hidden="true" />
           </a>
-          .
-        </p>
+        </div>
       </div>
     </section>
   )

--- a/components/Contact.tsx
+++ b/components/Contact.tsx
@@ -62,7 +62,7 @@ export default function Contact() {
     <section id="contact" className="border-t border-line py-24 md:py-28">
       <div className="container-max section-padding">
         <div>
-          <p className="eyebrow mb-4">08 — Work</p>
+          <p className="eyebrow mb-4">08 — Contact</p>
           <h2 className="section-title">Work with me</h2>
           <p className="mt-4 max-w-3xl text-lg leading-relaxed text-muted">
             I&apos;m a security engineer at the Ethereum Foundation. Beyond that, I&apos;m glad to

--- a/components/Contact.tsx
+++ b/components/Contact.tsx
@@ -1,6 +1,7 @@
 import {
   FileDown,
   FlaskConical,
+  Github,
   GraduationCap,
   Key,
   Linkedin,
@@ -73,6 +74,15 @@ export default function Contact() {
             <a href={`mailto:${email}`} className="link-accent inline-flex items-center gap-2">
               <Mail size={15} />
               {email}
+            </a>
+            <a
+              href={`https://github.com/${social.github}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="link-accent inline-flex items-center gap-2"
+            >
+              <Github size={15} />
+              GitHub
             </a>
             <a
               href={`https://linkedin.com/in/${social.linkedin}`}

--- a/components/DisclosureLedger.tsx
+++ b/components/DisclosureLedger.tsx
@@ -8,6 +8,7 @@ import {
   soliditySecurityBugs,
   soliditySecuritySummary,
   solSmithPaperUrl,
+  solSmithPatchedMiscompilations,
 } from '@/lib/disclosures'
 
 const categoryDescriptions = [
@@ -132,8 +133,9 @@ export default function DisclosureLedger() {
             {soliditySecuritySummary.total} Solidity security-relevant bugs found by SolSmith
           </h2>
           <p className="mt-3 max-w-4xl text-sm leading-relaxed text-muted">
-            The SolSmith paper documents 25 patched miscompilation bugs found through semantic
-            differential fuzzing. Cross-referencing its linked reports with Solidity’s official{' '}
+            The SolSmith paper documents {solSmithPatchedMiscompilations} patched miscompilation
+            bugs found through semantic differential fuzzing. Cross-referencing its linked reports
+            with Solidity’s official{' '}
             <code className="font-mono text-xs text-fg">docs/bugs.json</code> ledger yields these{' '}
             {soliditySecuritySummary.total} exact matches. They are security-relevant compiler bug
             records, not CVEs; the severity and affected version ranges below come from the official
@@ -228,7 +230,7 @@ export default function DisclosureLedger() {
             rel="noopener noreferrer"
             className="link-accent inline-flex items-center gap-1.5 text-sm"
           >
-            SolSmith paper and all 25 findings
+            SolSmith paper and all {solSmithPatchedMiscompilations} findings
             <ExternalLink size={13} aria-hidden="true" />
           </a>
         </div>

--- a/components/Findings.tsx
+++ b/components/Findings.tsx
@@ -1,6 +1,10 @@
 import Link from 'next/link'
 import { ArrowRight, ExternalLink, FileText, GitMerge, ShieldAlert } from 'lucide-react'
-import { disclosureSummary, soliditySecuritySummary } from '@/lib/disclosures'
+import {
+  disclosureSummary,
+  soliditySecuritySummary,
+  solSmithPatchedMiscompilations,
+} from '@/lib/disclosures'
 import portfolioData from '@/data/portfolio.json'
 
 const typeIcons: Record<string, React.ReactNode> = {
@@ -43,9 +47,9 @@ export default function Findings() {
                 Open vSwitch, GNU oSIP2, Snort++, and tcpdump: {disclosureSummary.memoryCorruption}{' '}
                 memory-corruption findings, {disclosureSummary.outOfBoundsReads} out-of-bounds
                 reads, and {disclosureSummary.logicOrDos} logic/denial-of-service findings. The
-                compiler ledger separately maps {soliditySecuritySummary.total} of SolSmith’s 25
-                findings to Solidity’s official security-relevant bug records:{' '}
-                {soliditySecuritySummary.incorrectOptimization} optimizer bugs,{' '}
+                compiler ledger separately maps {soliditySecuritySummary.total} of SolSmith’s{' '}
+                {solSmithPatchedMiscompilations} findings to Solidity’s official security-relevant
+                bug records: {soliditySecuritySummary.incorrectOptimization} optimizer bugs,{' '}
                 {soliditySecuritySummary.codeGeneration} code-generation bug, and{' '}
                 {soliditySecuritySummary.frontEnd} front-end validation bug.
               </p>

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -16,8 +16,8 @@ export default function Footer() {
           <div className="md:col-span-2">
             <h3 className="mb-4 text-2xl font-semibold tracking-tight text-fg">{personal.name}</h3>
             <p className="mb-6 max-w-md text-muted">
-              Security engineer at the Ethereum Foundation. I test systems where independent
-              implementations must agree.
+              Differential testing for critical systems — turning disagreement between independent
+              implementations into reproducible evidence.
             </p>
             <div className="flex space-x-5">
               <a
@@ -62,13 +62,13 @@ export default function Footer() {
             <h4 className="eyebrow mb-4">Quick Links</h4>
             <ul className="space-y-2">
               <li>
-                <a href="#about" className="text-muted transition-colors hover:text-fg">
-                  About
+                <a href="#case-studies" className="text-muted transition-colors hover:text-fg">
+                  Case Studies
                 </a>
               </li>
               <li>
-                <a href="#case-studies" className="text-muted transition-colors hover:text-fg">
-                  Case Studies
+                <a href="#about" className="text-muted transition-colors hover:text-fg">
+                  About
                 </a>
               </li>
               <li>

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -13,14 +13,14 @@ interface NavItem {
 }
 
 const navigation: NavItem[] = [
-  { name: 'About', href: '#about', id: 'about' },
   { name: 'Case Studies', href: '#case-studies', id: 'case-studies' },
+  { name: 'About', href: '#about', id: 'about' },
   { name: 'Research', href: '#research', id: 'research' },
   { name: 'Findings', href: '#findings', id: 'findings' },
   { name: 'Talks', href: '#talks', id: 'talks' },
   { name: 'Papers', href: '#publications', id: 'publications' },
   { name: 'Blog', href: '/blog' },
-  { name: 'Work', href: '#contact', id: 'contact' },
+  { name: 'Contact', href: '#contact', id: 'contact' },
 ]
 
 // Hardcoded rather than imported from portfolio.json so this client component
@@ -39,8 +39,8 @@ const iconLinkClass = (size: string) =>
 // highlighted while the user scrolls through them.
 const sectionIds = [
   'home',
-  'about',
   'case-studies',
+  'about',
   'research',
   'findings',
   'talks',

--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -5,6 +5,7 @@ import { formatDate } from '@/lib/format'
 import {
   disclosureSummary,
   disclosureYearRange,
+  solSmithPaperUrl,
   solSmithPatchedMiscompilations,
 } from '@/lib/disclosures'
 import portfolioData from '@/data/portfolio.json'
@@ -166,9 +167,10 @@ export default function Hero({ latestPost, publicationsCount }: HeroProps) {
               <a href="#findings" className="link-accent">
                 findings
               </a>
-              ), and 25 miscompilation bugs found in the Solidity compiler (
+              ), and {solSmithPatchedMiscompilations} miscompilation bugs found in the Solidity
+              compiler (
               <a
-                href="https://arxiv.org/abs/2607.07217"
+                href={solSmithPaperUrl}
                 target="_blank"
                 rel="noopener noreferrer"
                 className="link-accent"

--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -2,7 +2,11 @@ import Link from 'next/link'
 import { ArrowDown, FileText } from 'lucide-react'
 import type { BlogPostMeta } from '@/lib/blog'
 import { formatDate } from '@/lib/format'
-import { disclosureSummary, disclosureYearRange, soliditySecuritySummary } from '@/lib/disclosures'
+import {
+  disclosureSummary,
+  disclosureYearRange,
+  solSmithPatchedMiscompilations,
+} from '@/lib/disclosures'
 import portfolioData from '@/data/portfolio.json'
 
 type LatestPost = Pick<BlogPostMeta, 'slug' | 'title' | 'date'>
@@ -101,8 +105,8 @@ function MethodTrace() {
 }
 
 // Derived from the findings ledgers so the hero can't drift from the evidence
-// it links to: the advisory URL tracks portfolio.json and the historical totals
-// track lib/disclosures.ts.
+// it links to: the advisory URL tracks portfolio.json and the totals track
+// lib/disclosures.ts.
 const advisories = portfolioData.findings.filter((f) => f.type === 'Security advisory')
 const advisoryUrl = advisories[0]?.url ?? '#findings'
 
@@ -114,9 +118,9 @@ export default function Hero({ latestPost, publicationsCount }: HeroProps) {
       href: '/findings/#cve-disclosures',
     },
     {
-      value: String(soliditySecuritySummary.total),
-      label: 'Solidity security-relevant bug records',
-      href: '/findings/#solidity-security-bugs',
+      value: String(solSmithPatchedMiscompilations),
+      label: 'patched compiler miscompilations',
+      href: '#findings',
     },
     // geth, Besu, Nethermind, Erigon, and revm — see caseStudies[0].approach.
     { value: '5', label: 'EVM implementations cross-checked', href: '#case-studies' },
@@ -225,9 +229,12 @@ export default function Hero({ latestPost, publicationsCount }: HeroProps) {
           ))}
         </div>
 
-        <div className="mt-8 flex flex-col items-start gap-3 sm:flex-row">
+        <div className="mt-8 flex flex-col items-start gap-3 sm:flex-row sm:flex-wrap">
           <a href="#case-studies" className="btn-primary px-6 py-3">
             See case studies
+          </a>
+          <a href="#contact" className="btn-ghost px-6 py-3">
+            Start a conversation
           </a>
           <a
             href={portfolioData.personal.cv}
@@ -240,10 +247,10 @@ export default function Hero({ latestPost, publicationsCount }: HeroProps) {
         </div>
 
         <a
-          href="#about"
+          href="#case-studies"
           className="focus-ring mx-auto mt-8 flex w-fit items-center gap-2 rounded-sm px-3 py-2 font-mono text-xs uppercase tracking-[0.16em] text-faint transition-colors hover:text-fg"
         >
-          Explore the method
+          Explore the evidence
           <ArrowDown size={15} aria-hidden="true" />
         </a>
       </div>

--- a/data/portfolio.json
+++ b/data/portfolio.json
@@ -1,7 +1,7 @@
 {
   "personal": {
     "name": "Bhargava Shastry",
-    "title": "Security Engineer & Researcher",
+    "title": "Differential Testing & Protocol Security",
     "description": "Differential testing for critical systems: turning disagreements between Ethereum clients, cryptographic libraries, and compilers into reproducible findings.",
     "location": "Remote",
     "email": "bshastry@posteo.de",

--- a/data/portfolio.json
+++ b/data/portfolio.json
@@ -2,7 +2,7 @@
   "personal": {
     "name": "Bhargava Shastry",
     "title": "Security Engineer & Researcher",
-    "description": "Security engineer at the Ethereum Foundation. Differential testing of Ethereum clients, post-quantum cryptography, and compilers — plus the AI-assisted triage pipelines that scale it.",
+    "description": "Differential testing for critical systems: turning disagreements between Ethereum clients, cryptographic libraries, and compilers into reproducible findings.",
     "location": "Remote",
     "email": "bshastry@posteo.de",
     "cv": "/media/Bhargava_Shastry_CV.pdf",

--- a/lib/disclosures.ts
+++ b/lib/disclosures.ts
@@ -312,6 +312,12 @@ export const soliditySecurityBugs: SoliditySecurityBug[] = [
   },
 ]
 
+// Total patched miscompilation bugs reported in the SolSmith paper
+// (solSmithPaperUrl). The seven bugs in soliditySecurityBugs are the subset
+// also catalogued in Solidity's security-relevant known-bug ledger; every
+// surface that cites the paper total must read it from here.
+export const solSmithPatchedMiscompilations = 25
+
 export const soliditySecuritySummary = {
   total: soliditySecurityBugs.length,
   incorrectOptimization: soliditySecurityBugs.filter(

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "typecheck": "tsc --noEmit",
-    "check": "npm run typecheck && npm run lint && npm run format:check"
+    "check": "npm run typecheck && npm run lint && npm run format:check",
+    "check:links": "node scripts/check-links.mjs"
   },
   "dependencies": {
     "js-yaml": "^4.2.0",

--- a/public/.well-known/security.txt
+++ b/public/.well-known/security.txt
@@ -1,0 +1,8 @@
+# Scope: this website and my personal open-source projects
+# (github.com/bshastry). For Ethereum protocol or client
+# vulnerabilities, use https://bounty.ethereum.org instead.
+Contact: mailto:bshastry@posteo.de
+Encryption: https://keybase.io/bshastry/pgp_keys.asc
+Preferred-Languages: en
+Canonical: https://bshastry.github.io/.well-known/security.txt
+Expires: 2027-07-01T00:00:00.000Z

--- a/scripts/check-links.mjs
+++ b/scripts/check-links.mjs
@@ -1,0 +1,83 @@
+// Internal-link audit over the static export in out/.
+//
+// Every recent site PR ran this audit by hand before merge; this encodes it as
+// a CI gate so a renamed route, moved media file, or dropped legacy shim fails
+// the build instead of shipping a broken inbound link.
+//
+// Checks every href/src in every exported HTML page that points inside the
+// site (external URLs, mailto:, and pure-fragment links are out of scope).
+// A directory target passes only if it contains an index.html, matching how
+// GitHub Pages serves trailing-slash URLs.
+
+import { readdirSync, readFileSync, existsSync, statSync } from 'node:fs'
+import { join, dirname, normalize } from 'node:path'
+
+const OUT_DIR = 'out'
+
+function htmlFiles(dir) {
+  return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const path = join(dir, entry.name)
+    if (entry.isDirectory()) return htmlFiles(path)
+    return entry.name.endsWith('.html') ? [path] : []
+  })
+}
+
+function decodeEntities(url) {
+  return url
+    .replaceAll('&amp;', '&')
+    .replaceAll('&#x27;', "'")
+    .replaceAll('&quot;', '"')
+    .replaceAll('&lt;', '<')
+    .replaceAll('&gt;', '>')
+}
+
+function targetExists(fsPath) {
+  if (!existsSync(fsPath)) {
+    return existsSync(fsPath + '.html')
+  }
+  if (statSync(fsPath).isDirectory()) {
+    return existsSync(join(fsPath, 'index.html'))
+  }
+  return true
+}
+
+if (!existsSync(OUT_DIR)) {
+  console.error(`check-links: ${OUT_DIR}/ not found — run \`npm run build\` first.`)
+  process.exit(1)
+}
+
+const pages = htmlFiles(OUT_DIR)
+const broken = []
+let checked = 0
+
+for (const page of pages) {
+  const content = readFileSync(page, 'utf8')
+  for (const match of content.matchAll(/(?:href|src)="([^"]+)"/g)) {
+    const url = decodeEntities(match[1])
+    if (/^(https?:|mailto:|tel:|data:|#)/.test(url)) continue
+
+    const path = decodeURIComponent(url.split('#')[0].split('?')[0])
+    if (path === '') continue
+
+    const fsPath = path.startsWith('/')
+      ? join(OUT_DIR, ...path.slice(1).split('/'))
+      : normalize(join(dirname(page), path))
+
+    checked += 1
+    if (!targetExists(fsPath)) {
+      broken.push({ page, url })
+    }
+  }
+}
+
+console.log(`check-links: ${pages.length} pages, ${checked} internal references checked.`)
+
+if (broken.length > 0) {
+  console.error(`check-links: ${broken.length} broken internal link(s):`)
+  for (const { page, url } of broken) {
+    console.error(`  ${page} -> ${url}`)
+  }
+  process.exit(1)
+}
+
+console.log('check-links: no broken internal links.')

--- a/scripts/check-links.mjs
+++ b/scripts/check-links.mjs
@@ -10,7 +10,7 @@
 // GitHub Pages serves trailing-slash URLs.
 
 import { readdirSync, readFileSync, existsSync, statSync } from 'node:fs'
-import { join, dirname, normalize } from 'node:path'
+import { join, dirname, normalize, resolve, sep } from 'node:path'
 
 const OUT_DIR = 'out'
 
@@ -50,13 +50,28 @@ const pages = htmlFiles(OUT_DIR)
 const broken = []
 let checked = 0
 
+// Known limitations: `#fragment` targets are not validated against `id=`
+// attributes, and only double-quoted href/src attributes are matched (all
+// Next.js output uses double quotes; srcset is not emitted by this site).
+const outRoot = resolve(OUT_DIR)
+
 for (const page of pages) {
   const content = readFileSync(page, 'utf8')
   for (const match of content.matchAll(/(?:href|src)="([^"]+)"/g)) {
     const url = decodeEntities(match[1])
-    if (/^(https?:|mailto:|tel:|data:|#)/.test(url)) continue
+    // `//host/path` is protocol-relative, i.e. external — not a file in out/.
+    if (/^(https?:|mailto:|tel:|data:|#|\/\/)/.test(url)) continue
 
-    const path = decodeURIComponent(url.split('#')[0].split('?')[0])
+    let path
+    try {
+      path = decodeURIComponent(url.split('#')[0].split('?')[0])
+    } catch {
+      // Malformed percent-encoding would 404 (or worse) in a real browser;
+      // report it instead of crashing the audit.
+      broken.push({ page, url: `${url} (malformed percent-encoding)` })
+      checked += 1
+      continue
+    }
     if (path === '') continue
 
     const fsPath = path.startsWith('/')
@@ -64,6 +79,12 @@ for (const page of pages) {
       : normalize(join(dirname(page), path))
 
     checked += 1
+    // A `..`-laden URL can resolve outside out/ and accidentally match a repo
+    // file that will never be deployed — treat any escape as broken.
+    if (!resolve(fsPath).startsWith(outRoot + sep) && resolve(fsPath) !== outRoot) {
+      broken.push({ page, url: `${url} (resolves outside ${OUT_DIR}/)` })
+      continue
+    }
     if (!targetExists(fsPath)) {
       broken.push({ page, url })
     }


### PR DESCRIPTION
## Summary

Two complementary improvement passes on the site, merged into one branch after cross-review.

### Positioning & conversion (synthesized from a separately reviewed brand-improvement patch)

- **Proof-first architecture:** case studies now directly follow the hero; About/career chronology moves after the evidence. Nav order, footer quick links, and section numbering updated to match.
- **Portable brand:** site title, meta description, keywords, and footer now lead with "Differential Testing & Protocol Security" / differential testing for critical systems — the method owns the identity, while the Ethereum Foundation affiliation remains the credibility signal in the hero eyebrow, OG-card footer, and Person JSON-LD.
- **Rebuilt Open Graph card** in the site's own visual language: accent-dot eyebrow, method statement, domain chips (Ethereum clients / cryptographic libraries / compilers), affiliation + URL footer. Verified as a valid 1200×630 render in the build.
- **Conversion paths:** hero gains a direct "Start a conversation" CTA alongside case studies/CV; the case-study section closes with a visible CTA block addressed to system owners and team builders; nav "Work" renamed to the unambiguous "Contact".
- **Hero stat legibility:** the seven-record ledger count is replaced by the paper-backed "25 patched compiler miscompilations". Synthesis correction: the number is **not** hardcoded (the original patch typed `'25'` inline); it derives from a new documented `solSmithPatchedMiscompilations` constant in `lib/disclosures.ts`, preserving this repo's derived-counts convention, and the drift-guard comment the patch had removed is restored.

### Hardening & durability (first pass)

- **Branded 404 page** (`app/not-found.tsx`): decayed Jekyll-era inbound links no longer dead-end on Next.js's default page; visitors are routed back into `/findings/`, `/research/`, and `/blog/`.
- **RFC 9116 `security.txt`** (`public/.well-known/security.txt`): vulnerability-report contact with PGP key, scoped to this site and personal OSS; Ethereum protocol reports pointed at bounty.ethereum.org. `Expires` 2027-07-01 (renew yearly; noted in README).
- **CI link-audit gate** (`scripts/check-links.mjs` + `npm run check:links`): the internal-link audit previous PRs ran by hand is now enforced after every build. Negative-tested: an injected broken link fails with exit 1. (Required narrowing `.gitignore`'s blanket `scripts/` rule, which had silently excluded the script from the first commit.)
- **Contact section GitHub link** and **Person JSON-LD enrichment** (Ph.D. credential, Keybase, compiler security).

## Verification

- `npm run check` (tsc, ESLint, Prettier): pass
- `npm run build`: static export, 69 pages
- `npm run check:links`: 61 HTML pages, 810 internal references, 0 broken
- OG image inspected: renders the new design correctly
- Homepage screenshotted at 1440 px and 390 px after the reorder: case studies follow the hero, all three hero CTAs render, no horizontal overflow at mobile width
- 404 page and `/.well-known/security.txt` confirmed present in the export

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019hhB3TsV5mJ8x69WTNHqYJ