### PR TITLE
Fix post-reorder polish regressions: border seam and duplicate CTA target

### DIFF
--- a/components/CaseStudies.tsx
+++ b/components/CaseStudies.tsx
@@ -5,8 +5,10 @@ import { ArrowRight } from 'lucide-react'
 export default function CaseStudies() {
   const { caseStudies } = portfolioData
 
+  // No border-t on this section: the hero above already closes with border-b,
+  // and doubling them produced a 2px seam once this moved directly below it.
   return (
-    <section id="case-studies" className="border-t border-line bg-surface/30 py-24 md:py-28">
+    <section id="case-studies" className="bg-surface/30 py-24 md:py-28">
       <div className="container-max section-padding">
         <div className="mb-16">
           <p className="eyebrow mb-4">01 — Case Studies</p>

--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -248,8 +248,10 @@ export default function Hero({ latestPost, publicationsCount }: HeroProps) {
           </a>
         </div>
 
+        {/* Distinct destination from the "See case studies" CTA above: this
+            cue goes to the findings evidence index, matching its label. */}
         <a
-          href="#case-studies"
+          href="#findings"
           className="focus-ring mx-auto mt-8 flex w-fit items-center gap-2 rounded-sm px-3 py-2 font-mono text-xs uppercase tracking-[0.16em] text-faint transition-colors hover:text-fg"
         >
           Explore the evidence


### PR DESCRIPTION
## Summary

Follow-up to #39, from a regression review of the section-reorder change set against the PR #36 design/accessibility pass. Verdict on the three reported findings:

- **Hardcoded `25` in the hero (medium)** — already resolved on master: the stat and all four prose surfaces derive from `solSmithPatchedMiscompilations` in `lib/disclosures.ts` (landed in #39's review-fix commit). No change here.
- **2px border seam (low)** — real. The hero closes with `border-b` and Case Studies carried its own `border-t` from its old position after the borderless About section; stacked directly, they doubled. Case Studies drops its `border-t`, matching the page's border rhythm (only the hero bottom and contact top carry section borders). Verified with a boundary close-up screenshot: single 1px line.
- **Duplicate CTA destination (low)** — real. The "Explore the evidence" scroll cue duplicated the "See case studies" button's `#case-studies` target. It now points at `#findings` — the evidence index its label literally describes — keeping the scroll affordance while giving each CTA a distinct destination.

Also closes the interactive-browser gap the review flagged at the `lg` boundary: rendered at 1023px and 1024px with no horizontal overflow and correct single/two-column hero layouts.

All PR #36 fixes were confirmed intact (anchor offset, menu reset, Escape focus restoration, progress bar, ARIA, touch targets, focus styling, data-driven social links, font variable, server-rendered hero).

## Verification

- `npm run check` and `npm run build` (69 pages): pass
- `npm run check:links`: 0 broken internal links
- Boundary screenshot at the hero/case-studies seam: single border
- 1023px / 1024px renders: no overflow, layouts correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019hhB3TsV5mJ8x69WTNHqYJ

---
_Generated by [Claude Code](https://claude.ai/code/session_019hhB3TsV5mJ8x69WTNHqYJ)_