### PR TITLE
Add audience routes, service-detail pages, share actions, and distribution playbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ app/
       BlogPostClient.tsx  Share button + layout
   research/               Full research-area archive (homepage features 5)
   findings/               CVE + Solidity security-relevant bug ledgers
+  engagements/            Engagement index + evidence-backed service detail routes
+  recruiter-brief/        Concise hiring-team route through fit and evidence
   bugs/                   No-index legacy alias for /findings
   privacy/, terms/        Static legal pages
   feed.xml/               RSS feed generator
@@ -82,9 +84,13 @@ components/
 
 content/posts/            Blog markdown files
 
+docs/
+  distribution-playbook.md  Channel selection, profile copy, and measurement cadence
+
 lib/
   blog.ts                 Markdown parsing pipeline
   disclosures.ts          CVE and Solidity known-bug ledgers + aggregates
+  engagements.ts          Shared offers, detailed scopes, evidence links, enquiry builder
   seo.ts                  Site constants, canonical/RSS alternates, JSON-LD serializer
 
 data/
@@ -117,6 +123,8 @@ No custom domain is configured; the site serves from the default `bshastry.githu
 - **Dependencies:** Update periodically with `npm outdated` + `npm update`. For major bumps (Next.js, Tailwind), test thoroughly in a branch first.
 - **Legacy continuity:** Keep the static redirect files under `public/` and the `/bugs/` alias when changing routes; external links to the Jekyll-era site still depend on them.
 - **Content updates:** Blog posts live in `content/posts/`; portfolio data (projects, CV) lives in `data/portfolio.json`.
+- **Distribution:** Use [`docs/distribution-playbook.md`](docs/distribution-playbook.md) for
+  channel selection, profile alignment, community rules, and the six-week review cadence.
 
 ## License
 

--- a/app/blog/[slug]/BlogPostClient.tsx
+++ b/app/blog/[slug]/BlogPostClient.tsx
@@ -1,9 +1,22 @@
 'use client'
 
+import { useState } from 'react'
 import Link from 'next/link'
-import { Calendar, Clock, ArrowLeft, Tag, Share2 } from 'lucide-react'
+import {
+  ArrowLeft,
+  Calendar,
+  Check,
+  Clock,
+  Copy,
+  ExternalLink,
+  Linkedin,
+  Share2,
+  Tag,
+  Twitter,
+} from 'lucide-react'
 import type { BlogPost, BlogPostMeta, SeriesPart } from '@/lib/blog'
 import { formatDate } from '@/lib/format'
+import { SITE_URL } from '@/lib/seo'
 import ThemeToggle from '@/components/ThemeToggle'
 import { SeriesNav, SeriesPager } from '@/components/SeriesNav'
 import { PostTitle } from '@/components/PostTitle'
@@ -21,21 +34,50 @@ export default function BlogPostClient({
   seriesTitle,
   seriesParts,
 }: BlogPostClientProps) {
+  const [copyStatus, setCopyStatus] = useState<'idle' | 'copied'>('idle')
+  const canonicalUrl = `${SITE_URL}/blog/${post.slug}/`
+
+  const handleCopy = async () => {
+    await navigator.clipboard.writeText(canonicalUrl)
+    setCopyStatus('copied')
+    window.setTimeout(() => setCopyStatus('idle'), 2000)
+  }
+
   const handleShare = async () => {
     if (navigator.share) {
       try {
         await navigator.share({
           title: post.title,
           text: post.excerpt,
-          url: window.location.href,
+          url: canonicalUrl,
         })
       } catch {
         // user cancelled
       }
     } else {
-      await navigator.clipboard.writeText(window.location.href)
+      await handleCopy()
     }
   }
+
+  const encodedUrl = encodeURIComponent(canonicalUrl)
+  const encodedTitle = encodeURIComponent(post.title)
+  const shareLinks = [
+    {
+      label: 'Post to X',
+      href: `https://twitter.com/intent/tweet?text=${encodedTitle}&url=${encodedUrl}`,
+      Icon: Twitter,
+    },
+    {
+      label: 'Share on LinkedIn',
+      href: `https://www.linkedin.com/sharing/share-offsite/?url=${encodedUrl}`,
+      Icon: Linkedin,
+    },
+    {
+      label: 'Submit to Hacker News',
+      href: `https://news.ycombinator.com/submitlink?u=${encodedUrl}&t=${encodedTitle}`,
+      Icon: ExternalLink,
+    },
+  ]
 
   const related = allPosts
     .filter((p) => p.slug !== post.slug && p.tags.some((t) => post.tags.includes(t)))
@@ -120,6 +162,46 @@ export default function BlogPostClient({
             />
           </article>
 
+          <aside
+            aria-labelledby="share-this-post"
+            className="mt-12 rounded-xl border border-line bg-surface/40 p-5 sm:flex sm:items-center sm:justify-between sm:gap-6"
+          >
+            <div>
+              <h2 id="share-this-post" className="text-sm font-semibold text-fg">
+                Share the original article
+              </h2>
+              <p className="mt-1 text-xs leading-relaxed text-faint">
+                Use the canonical source and original title; no tracking parameters are added.
+              </p>
+            </div>
+            <div className="mt-4 flex flex-wrap gap-2 sm:mt-0 sm:justify-end">
+              <button
+                type="button"
+                onClick={handleCopy}
+                className="btn-ghost inline-flex items-center gap-2 px-3 py-2 text-xs"
+              >
+                {copyStatus === 'copied' ? (
+                  <Check size={14} aria-hidden="true" />
+                ) : (
+                  <Copy size={14} aria-hidden="true" />
+                )}
+                {copyStatus === 'copied' ? 'Copied' : 'Copy link'}
+              </button>
+              {shareLinks.map(({ label, href, Icon }) => (
+                <a
+                  key={label}
+                  href={href}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="btn-ghost inline-flex items-center gap-2 px-3 py-2 text-xs"
+                >
+                  <Icon size={14} aria-hidden="true" />
+                  {label}
+                </a>
+              ))}
+            </div>
+          </aside>
+
           <SeriesPager parts={seriesParts} />
 
           {related.length > 0 && (
@@ -155,11 +237,15 @@ export default function BlogPostClient({
             <p className="max-w-2xl text-sm leading-relaxed text-muted">
               If you work on a system where independent implementations must agree — an Ethereum
               client, a cryptographic library, a compiler — I take on a small number of scoped
-              differential-testing engagements and workshops.
+              differential-testing engagements and workshops. Hiring teams can use the recruiter
+              brief for a concise view of role fit and evidence.
             </p>
             <div className="mt-4 flex flex-wrap items-center gap-x-6 gap-y-2 text-sm">
-              <Link href="/#contact" className="link-accent font-medium">
-                Discuss a scoped review
+              <Link href="/engagements" className="link-accent font-medium">
+                Explore engagements
+              </Link>
+              <Link href="/recruiter-brief" className="link-accent font-medium">
+                Recruiter brief
               </Link>
               <Link href="/#case-studies" className="link-accent font-medium">
                 See case studies

--- a/app/engagements/[slug]/page.tsx
+++ b/app/engagements/[slug]/page.tsx
@@ -1,0 +1,231 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import { notFound } from 'next/navigation'
+import { ArrowLeft, ArrowRight, Key, Mail } from 'lucide-react'
+import Header from '@/components/Header'
+import Footer from '@/components/Footer'
+import portfolioData from '@/data/portfolio.json'
+import { engagementGuides, getEngagementGuide, getEngagementInquiryHref } from '@/lib/engagements'
+import { pageAlternates, serializeJsonLd, SITE_URL } from '@/lib/seo'
+
+interface EngagementGuidePageProps {
+  params: Promise<{ slug: string }>
+}
+
+export function generateStaticParams() {
+  return engagementGuides.map((guide) => ({ slug: guide.slug }))
+}
+
+export async function generateMetadata({ params }: EngagementGuidePageProps): Promise<Metadata> {
+  const { slug } = await params
+  const guide = getEngagementGuide(slug)
+  if (!guide) return {}
+
+  const canonical = `/engagements/${guide.slug}/`
+  return {
+    title: guide.metadataTitle,
+    description: guide.metadataDescription,
+    alternates: pageAlternates(canonical),
+    openGraph: {
+      type: 'website',
+      title: guide.metadataTitle,
+      description: guide.metadataDescription,
+      url: `${SITE_URL}${canonical}`,
+    },
+  }
+}
+
+function EvidenceLink({ href, label }: { href: string; label: string }) {
+  const className =
+    'link-accent inline-flex items-center gap-2 text-sm font-medium focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent'
+
+  if (href.startsWith('http')) {
+    return (
+      <a href={href} target="_blank" rel="noopener noreferrer" className={className}>
+        <span>{label}</span>
+        <ArrowRight size={14} aria-hidden="true" />
+      </a>
+    )
+  }
+
+  return (
+    <Link href={href} className={className}>
+      <span>{label}</span>
+      <ArrowRight size={14} aria-hidden="true" />
+    </Link>
+  )
+}
+
+export default async function EngagementGuidePage({ params }: EngagementGuidePageProps) {
+  const { slug } = await params
+  const guide = getEngagementGuide(slug)
+  if (!guide) notFound()
+
+  const canonicalUrl = `${SITE_URL}/engagements/${guide.slug}/`
+  const inquiryHref = getEngagementInquiryHref(guide.label)
+  const serviceJsonLd = {
+    '@context': 'https://schema.org',
+    '@type': 'Service',
+    name: guide.metadataTitle,
+    serviceType: guide.serviceType,
+    url: canonicalUrl,
+    description: guide.metadataDescription,
+    provider: {
+      '@type': 'Person',
+      name: 'Bhargava Shastry',
+      url: SITE_URL,
+    },
+    audience: {
+      '@type': 'Audience',
+      audienceType: guide.audience,
+    },
+  }
+
+  return (
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: serializeJsonLd(serviceJsonLd) }}
+      />
+      <Header />
+      <main id="main-content" className="min-h-screen bg-bg pt-16">
+        <section className="border-b border-line">
+          <div className="container-max section-padding py-14 sm:py-20">
+            <nav aria-label="Breadcrumb" className="mb-8">
+              <Link
+                href="/engagements/"
+                className="link-accent inline-flex items-center gap-2 text-sm"
+              >
+                <ArrowLeft size={15} aria-hidden="true" />
+                All engagement options
+              </Link>
+            </nav>
+            <p className="eyebrow mb-4 text-accent">{guide.eyebrow}</p>
+            <h1 className="max-w-4xl text-balance text-4xl font-semibold tracking-tight text-fg sm:text-5xl">
+              {guide.heading}
+            </h1>
+            <p className="mt-6 max-w-3xl text-xl leading-relaxed text-muted">{guide.lead}</p>
+            <div className="mt-8 flex flex-col items-start gap-3 sm:flex-row sm:flex-wrap">
+              <a
+                href={inquiryHref}
+                className="btn-primary inline-flex items-center gap-2 px-6 py-3"
+              >
+                <Mail size={16} aria-hidden="true" />
+                Start a structured enquiry
+              </a>
+              <Link href="/#case-studies" className="btn-ghost px-6 py-3">
+                Review public evidence
+              </Link>
+            </div>
+          </div>
+        </section>
+
+        <section className="container-max section-padding py-16 md:py-20">
+          <div className="grid grid-cols-1 gap-12 lg:grid-cols-[minmax(0,1fr)_minmax(18rem,0.48fr)]">
+            <div>
+              <h2 className="section-title">When this is useful</h2>
+              <ul className="mt-6 space-y-4">
+                {guide.situations.map((situation) => (
+                  <li key={situation} className="flex gap-3 text-muted">
+                    <span
+                      aria-hidden="true"
+                      className="mt-2.5 h-1.5 w-1.5 flex-shrink-0 rounded-full bg-accent"
+                    />
+                    <span className="leading-relaxed">{situation}</span>
+                  </li>
+                ))}
+              </ul>
+
+              <h2 className="section-title mt-16">How the work proceeds</h2>
+              <ol className="mt-7 divide-y divide-line border-y border-line">
+                {guide.phases.map((phase, index) => (
+                  <li key={phase.title} className="grid gap-3 py-6 sm:grid-cols-[3rem_1fr]">
+                    <span className="font-mono text-sm text-accent">
+                      {String(index + 1).padStart(2, '0')}
+                    </span>
+                    <div>
+                      <h3 className="font-semibold text-fg">{phase.title}</h3>
+                      <p className="mt-2 text-sm leading-relaxed text-muted">{phase.description}</p>
+                    </div>
+                  </li>
+                ))}
+              </ol>
+            </div>
+
+            <aside className="h-fit rounded-xl border border-line bg-surface/50 p-6">
+              <p className="eyebrow text-accent">Typical outputs</p>
+              <ul className="mt-5 space-y-3 text-sm leading-relaxed text-muted">
+                {guide.outputs.map((output) => (
+                  <li key={output} className="flex gap-3">
+                    <span aria-hidden="true" className="text-accent">
+                      —
+                    </span>
+                    <span>{output}</span>
+                  </li>
+                ))}
+              </ul>
+              <div className="mt-7 border-t border-line pt-6">
+                <p className="eyebrow mb-3">Scope boundary</p>
+                <p className="text-sm leading-relaxed text-muted">{guide.boundary}</p>
+              </div>
+            </aside>
+          </div>
+
+          <div className="mt-16 border-t border-line pt-12">
+            <p className="eyebrow mb-4 text-accent">Public evidence</p>
+            <h2 className="section-title">Start with work you can inspect</h2>
+            <div className="mt-7 grid grid-cols-1 gap-4 md:grid-cols-3">
+              {guide.evidence.map((item) => (
+                <article
+                  key={item.href}
+                  className="rounded-xl border border-line bg-surface/40 p-5"
+                >
+                  <p className="min-h-16 text-sm leading-relaxed text-muted">{item.description}</p>
+                  <div className="mt-5">
+                    <EvidenceLink href={item.href} label={item.label} />
+                  </div>
+                </article>
+              ))}
+            </div>
+          </div>
+
+          <div className="mt-16 rounded-xl border border-line bg-surface/50 p-6 sm:p-8">
+            <p className="eyebrow text-accent">Next step</p>
+            <h2 className="mt-3 text-2xl font-semibold text-fg">
+              Describe the decision, not secrets
+            </h2>
+            <p className="mt-4 max-w-3xl text-sm leading-relaxed text-muted">
+              A short, non-confidential note about the system, milestone, desired evidence, timing,
+              and possible Ethereum Foundation conflicts is enough to begin. Do not email
+              vulnerability details, source code, credentials, or secrets.
+            </p>
+            <div className="mt-6 flex flex-col items-start gap-3 sm:flex-row sm:flex-wrap">
+              <a
+                href={inquiryHref}
+                className="btn-primary inline-flex items-center gap-2 px-6 py-3"
+              >
+                <Mail size={16} aria-hidden="true" />
+                Start a structured enquiry
+              </a>
+              <a
+                href={`https://keybase.io/${portfolioData.personal.social.keybase}/pgp_keys.asc`}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="btn-ghost inline-flex items-center gap-2 px-6 py-3"
+              >
+                <Key size={16} aria-hidden="true" />
+                PGP key
+              </a>
+            </div>
+            <p className="mt-7 max-w-3xl text-xs leading-relaxed text-faint">
+              Independent engagements are limited, subject to conflict review, and represent my own
+              views and work. They are not offered, endorsed, or reviewed by the Ethereum
+              Foundation.
+            </p>
+          </div>
+        </section>
+      </main>
+      <Footer />
+    </>
+  )
+}

--- a/app/engagements/page.tsx
+++ b/app/engagements/page.tsx
@@ -1,0 +1,86 @@
+import type { Metadata } from 'next'
+import Header from '@/components/Header'
+import Footer from '@/components/Footer'
+import Engagements from '@/components/Engagements'
+import { engagementOffers } from '@/lib/engagements'
+import { pageAlternates, serializeJsonLd, SITE_URL } from '@/lib/seo'
+
+export const metadata: Metadata = {
+  title: 'Differential Testing & Protocol Security Engagements',
+  description:
+    'Independent differential fuzzing, Ethereum client and implementation review, constant-time analysis, and team workshops for critical systems.',
+  alternates: pageAlternates('/engagements/'),
+  openGraph: {
+    title: 'Differential Testing & Protocol Security Engagements',
+    description:
+      'Conflict-screened security engagements for critical multi-implementation systems approaching a release, upgrade, or standardization milestone.',
+    url: `${SITE_URL}/engagements/`,
+  },
+}
+
+const serviceJsonLd = {
+  '@context': 'https://schema.org',
+  '@type': 'Service',
+  name: 'Differential Testing & Protocol Security Engagements',
+  url: `${SITE_URL}/engagements/`,
+  description:
+    'Independent differential testing, critical implementation review, and workshops for critical multi-implementation systems.',
+  provider: {
+    '@type': 'Person',
+    name: 'Bhargava Shastry',
+    url: SITE_URL,
+  },
+  hasOfferCatalog: {
+    '@type': 'OfferCatalog',
+    name: 'Scoped security engagements',
+    itemListElement: engagementOffers.map((engagement) => ({
+      '@type': 'Offer',
+      itemOffered: {
+        '@type': 'Service',
+        name: engagement.title,
+        description: `${engagement.audience} ${engagement.deliverables}`,
+      },
+    })),
+  },
+}
+
+export default function EngagementsPage() {
+  return (
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: serializeJsonLd(serviceJsonLd) }}
+      />
+      <Header />
+      <main id="main-content" className="min-h-screen bg-bg pt-16">
+        <section className="border-b border-line">
+          <div className="container-max section-padding py-16 sm:py-20">
+            <p className="eyebrow mb-4 text-accent">Independent · conflict-screened</p>
+            <h1 className="max-w-4xl text-balance text-4xl font-semibold tracking-tight text-fg sm:text-5xl">
+              Differential testing for critical systems approaching a milestone
+            </h1>
+            <p className="mt-6 max-w-3xl text-xl leading-relaxed text-muted">
+              For teams that need independent evidence before a release, hard fork, protocol
+              upgrade, cryptographic rollout, or standardization decision.
+            </p>
+            <p className="mt-4 max-w-3xl text-sm leading-relaxed text-muted">
+              Detailed scopes cover differential fuzzing, client and protocol implementation review,
+              constant-time analysis, and team capability building. Each scope is tied to public
+              evidence and states what it does not cover.
+            </p>
+            <p className="mt-4 max-w-3xl text-sm leading-relaxed text-faint">
+              The ranges below are planning estimates for a focused scope, not availability
+              commitments. Timing is confirmed only after an Ethereum Foundation
+              conflict-of-interest check and an availability discussion.
+            </p>
+          </div>
+        </section>
+
+        <section className="container-max section-padding py-16 md:py-20">
+          <Engagements />
+        </section>
+      </main>
+      <Footer />
+    </>
+  )
+}

--- a/app/recruiter-brief/page.tsx
+++ b/app/recruiter-brief/page.tsx
@@ -1,0 +1,243 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import { ArrowRight, FileDown, Github, Linkedin, Mail, MapPin } from 'lucide-react'
+import Header from '@/components/Header'
+import Footer from '@/components/Footer'
+import portfolioData from '@/data/portfolio.json'
+import { disclosureSummary, solSmithPatchedMiscompilations } from '@/lib/disclosures'
+import { pageAlternates, serializeJsonLd, SITE_URL } from '@/lib/seo'
+
+export const metadata: Metadata = {
+  title: 'Protocol Security Engineer — Recruiter Brief',
+  description:
+    'Recruiter brief for Bhargava Shastry: protocol security, differential fuzzing, Ethereum client testing, compiler security, cryptographic implementations, and AI-assisted vulnerability research.',
+  alternates: pageAlternates('/recruiter-brief/'),
+  openGraph: {
+    title: 'Bhargava Shastry — Protocol Security Recruiter Brief',
+    description:
+      'A concise hiring-team view of role fit, current focus, public evidence, experience, and contact details.',
+    url: `${SITE_URL}/recruiter-brief/`,
+  },
+}
+
+const focusAreas = [
+  'Protocol security and multi-client consensus testing',
+  'Differential testing, coverage-guided fuzzing, and test-oracle design',
+  'Compiler, virtual-machine, and cryptographic implementation security',
+  'AI-assisted vulnerability discovery, PoC validation, and triage pipelines',
+]
+
+const recruiterJsonLd = {
+  '@context': 'https://schema.org',
+  '@type': 'ProfilePage',
+  name: 'Bhargava Shastry — Recruiter Brief',
+  url: `${SITE_URL}/recruiter-brief/`,
+  mainEntity: {
+    '@type': 'Person',
+    name: 'Bhargava Shastry',
+    url: SITE_URL,
+    jobTitle: 'Security Engineer',
+    worksFor: {
+      '@type': 'Organization',
+      name: 'Ethereum Foundation',
+    },
+    knowsAbout: focusAreas,
+  },
+}
+
+export default function RecruiterBriefPage() {
+  const { personal, experience, education } = portfolioData
+  const roleConversationHref = `mailto:${personal.email}?subject=${encodeURIComponent(
+    'Role conversation',
+  )}&body=${encodeURIComponent(`Organization and role:
+Why this background may be relevant:
+Working model or location constraint:
+Timing (if known):
+How did you find this page?:
+`)}`
+  const publicationsCount = portfolioData.publications.reduce(
+    (sum, group) => sum + group.papers.length,
+    0,
+  )
+
+  const stats = [
+    { value: `${experience[0].period}`, label: 'Ethereum Foundation' },
+    { value: String(solSmithPatchedMiscompilations), label: 'patched miscompilations found' },
+    { value: String(disclosureSummary.cves), label: 'CVE-backed disclosures' },
+    { value: String(publicationsCount), label: 'publications' },
+  ]
+
+  return (
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: serializeJsonLd(recruiterJsonLd) }}
+      />
+      <Header />
+      <main id="main-content" className="min-h-screen bg-bg pt-16">
+        <section className="border-b border-line">
+          <div className="container-max section-padding py-16 sm:py-20">
+            <p className="eyebrow mb-4 text-accent">For hiring teams</p>
+            <h1 className="max-w-4xl text-balance text-4xl font-semibold tracking-tight text-fg sm:text-5xl">
+              Protocol security, differential testing, and vulnerability research
+            </h1>
+            <p className="mt-6 max-w-3xl text-xl leading-relaxed text-muted">
+              I&apos;m established in my role at the Ethereum Foundation and glad to hear from teams
+              working on hard verification problems. This page is the shortest route through the
+              evidence; timing and fit are discussed directly.
+            </p>
+
+            <div className="mt-8 flex flex-col items-start gap-3 sm:flex-row sm:flex-wrap">
+              <a
+                href={personal.cv}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="btn-primary inline-flex items-center gap-2 px-6 py-3"
+              >
+                <FileDown size={16} aria-hidden="true" />
+                Download CV (PDF)
+              </a>
+              <a
+                href={roleConversationHref}
+                className="btn-ghost inline-flex items-center gap-2 px-6 py-3"
+              >
+                <Mail size={16} aria-hidden="true" />
+                Start a conversation
+              </a>
+            </div>
+          </div>
+        </section>
+
+        <section className="container-max section-padding py-16 md:py-20">
+          <div className="grid grid-cols-2 overflow-hidden rounded-xl border border-line bg-surface/50 md:grid-cols-4">
+            {stats.map((stat, index) => (
+              <div
+                key={stat.label}
+                className={`flex min-h-28 flex-col items-center justify-center gap-2 px-4 py-6 text-center ${
+                  index % 2 === 1 ? 'border-l border-line' : ''
+                } ${index < 2 ? 'border-b border-line md:border-b-0' : ''} ${
+                  index > 0 ? 'md:border-l md:border-line' : ''
+                }`}
+              >
+                <span className="font-mono text-xl font-semibold tracking-tight text-fg sm:text-2xl">
+                  {stat.value}
+                </span>
+                <span className="eyebrow text-center">{stat.label}</span>
+              </div>
+            ))}
+          </div>
+
+          <div className="mt-14 grid grid-cols-1 gap-12 lg:grid-cols-[minmax(0,1fr)_minmax(18rem,0.6fr)]">
+            <div>
+              <h2 className="section-title">Relevant mandates</h2>
+              <ul className="mt-6 space-y-4">
+                {focusAreas.map((area) => (
+                  <li key={area} className="flex gap-3 text-muted">
+                    <span
+                      aria-hidden="true"
+                      className="mt-2 h-1.5 w-1.5 flex-shrink-0 rounded-full bg-accent"
+                    />
+                    <span className="leading-relaxed">{area}</span>
+                  </li>
+                ))}
+              </ul>
+
+              <h2 className="section-title mt-14">Selected experience</h2>
+              <div className="mt-6 divide-y divide-line border-y border-line">
+                {experience.slice(0, 3).map((role) => (
+                  <article key={`${role.company}-${role.period}`} className="py-6">
+                    <p className="font-mono text-xs text-accent">{role.period}</p>
+                    <h3 className="mt-2 text-lg font-semibold text-fg">
+                      {role.title} · {role.company}
+                    </h3>
+                    <p className="mt-2 text-sm leading-relaxed text-muted">{role.description}</p>
+                  </article>
+                ))}
+              </div>
+            </div>
+
+            <aside className="h-fit rounded-xl border border-line bg-surface/50 p-6">
+              <p className="eyebrow text-accent">At a glance</p>
+              <dl className="mt-5 space-y-5 text-sm">
+                <div>
+                  <dt className="text-faint">Current role</dt>
+                  <dd className="mt-1 font-medium text-fg">
+                    Security Engineer · Ethereum Foundation
+                  </dd>
+                </div>
+                <div>
+                  <dt className="text-faint">Working model</dt>
+                  <dd className="mt-1 inline-flex items-center gap-2 font-medium text-fg">
+                    <MapPin size={14} aria-hidden="true" />
+                    {personal.location}
+                  </dd>
+                </div>
+                <div>
+                  <dt className="text-faint">Highest degree</dt>
+                  <dd className="mt-1 font-medium text-fg">
+                    {education[0].degree} · {education[0].institution}
+                  </dd>
+                </div>
+                <div>
+                  <dt className="text-faint">Availability</dt>
+                  <dd className="mt-1 leading-relaxed text-muted">
+                    Selective conversations; timing and fit discussed directly.
+                  </dd>
+                </div>
+              </dl>
+
+              <div className="mt-7 flex flex-col items-start gap-3 border-t border-line pt-6 text-sm">
+                <a
+                  href={`https://linkedin.com/in/${personal.social.linkedin}`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="link-accent inline-flex items-center gap-2"
+                >
+                  <Linkedin size={15} aria-hidden="true" />
+                  LinkedIn
+                </a>
+                <a
+                  href={`https://github.com/${personal.social.github}`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="link-accent inline-flex items-center gap-2"
+                >
+                  <Github size={15} aria-hidden="true" />
+                  GitHub
+                </a>
+                <a
+                  href={`mailto:${personal.email}`}
+                  className="link-accent inline-flex items-center gap-2"
+                >
+                  <Mail size={15} aria-hidden="true" />
+                  {personal.email}
+                </a>
+              </div>
+            </aside>
+          </div>
+
+          <div className="mt-16 border-t border-line pt-10">
+            <p className="eyebrow mb-4 text-accent">Start with the evidence</p>
+            <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+              {[
+                ['Case studies', '/#case-studies'],
+                ['Security findings', '/findings/'],
+                ['Research archive', '/research/'],
+              ].map(([label, href]) => (
+                <Link
+                  key={href}
+                  href={href}
+                  className="focus-ring group flex items-center justify-between rounded-lg border border-line bg-surface/40 px-5 py-4 text-sm font-medium text-fg transition-colors hover:border-line-strong"
+                >
+                  <span>{label}</span>
+                  <ArrowRight size={15} className="text-accent" aria-hidden="true" />
+                </Link>
+              ))}
+            </div>
+          </div>
+        </section>
+      </main>
+      <Footer />
+    </>
+  )
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,5 +1,6 @@
 import type { MetadataRoute } from 'next'
 import { getAllPostsMeta } from '@/lib/blog'
+import { engagementGuides } from '@/lib/engagements'
 export const dynamic = 'force-static'
 
 const BASE = 'https://bshastry.github.io'
@@ -10,6 +11,8 @@ export default function sitemap(): MetadataRoute.Sitemap {
     { url: `${BASE}/blog/`, changeFrequency: 'weekly', priority: 0.9 },
     { url: `${BASE}/research/`, changeFrequency: 'monthly', priority: 0.8 },
     { url: `${BASE}/findings/`, changeFrequency: 'monthly', priority: 0.8 },
+    { url: `${BASE}/engagements/`, changeFrequency: 'monthly', priority: 0.9 },
+    { url: `${BASE}/recruiter-brief/`, changeFrequency: 'monthly', priority: 0.9 },
     { url: `${BASE}/privacy/`, changeFrequency: 'yearly', priority: 0.3 },
     { url: `${BASE}/terms/`, changeFrequency: 'yearly', priority: 0.3 },
   ]
@@ -19,5 +22,10 @@ export default function sitemap(): MetadataRoute.Sitemap {
     changeFrequency: 'yearly',
     priority: 0.7,
   }))
-  return [...staticRoutes, ...postRoutes]
+  const engagementRoutes: MetadataRoute.Sitemap = engagementGuides.map((guide) => ({
+    url: `${BASE}/engagements/${guide.slug}/`,
+    changeFrequency: 'monthly',
+    priority: 0.8,
+  }))
+  return [...staticRoutes, ...engagementRoutes, ...postRoutes]
 }

--- a/components/CaseStudies.tsx
+++ b/components/CaseStudies.tsx
@@ -1,5 +1,6 @@
 import portfolioData from '@/data/portfolio.json'
 import { ThemeLink } from '@/components/ResearchGrid'
+import Link from 'next/link'
 import { ArrowRight } from 'lucide-react'
 
 export default function CaseStudies() {
@@ -24,7 +25,8 @@ export default function CaseStudies() {
           {caseStudies.map((cs, index) => (
             <article
               key={cs.id}
-              className="relative overflow-hidden rounded-xl border border-line bg-bg/80 p-6 md:p-8"
+              id={cs.id}
+              className="relative scroll-mt-24 overflow-hidden rounded-xl border border-line bg-bg/80 p-6 md:p-8"
             >
               <span aria-hidden="true" className="absolute bottom-8 left-0 top-8 w-px bg-accent" />
               <div className="mb-3 flex items-center gap-3">
@@ -71,13 +73,18 @@ export default function CaseStudies() {
               building the team that is?
             </p>
           </div>
-          <a
-            href="#contact"
-            className="btn-primary inline-flex flex-shrink-0 items-center gap-2 px-5 py-2.5"
-          >
-            <span>Start a conversation</span>
-            <ArrowRight size={15} aria-hidden="true" />
-          </a>
+          <div className="flex flex-wrap gap-3">
+            <Link
+              href="/engagements"
+              className="btn-primary inline-flex flex-shrink-0 items-center gap-2 px-5 py-2.5"
+            >
+              <span>Explore engagements</span>
+              <ArrowRight size={15} aria-hidden="true" />
+            </Link>
+            <Link href="/recruiter-brief" className="btn-ghost px-5 py-2.5">
+              Recruiter brief
+            </Link>
+          </div>
         </div>
       </div>
     </section>

--- a/components/Contact.tsx
+++ b/components/Contact.tsx
@@ -1,199 +1,71 @@
-import {
-  FileDown,
-  FlaskConical,
-  Github,
-  GraduationCap,
-  Key,
-  Linkedin,
-  Mail,
-  ShieldCheck,
-} from 'lucide-react'
+import Link from 'next/link'
+import { ArrowRight, Briefcase, Mail, ShieldCheck } from 'lucide-react'
 import portfolioData from '@/data/portfolio.json'
 
-const engagements = [
+const paths = [
   {
-    icon: FlaskConical,
-    title: 'Differential-testing diagnostic',
-    mechanics: 'Typical duration · 1–2 weeks',
-    audience: 'For teams that suspect cross-implementation or oracle risk.',
-    deliverables:
-      'A divergence and threat model, a target matrix, a harness and coverage roadmap, and a prioritized-risk debrief — the same artifact structure as the case studies above.',
+    icon: Briefcase,
+    eyebrow: 'For hiring teams',
+    title: 'Evaluate role fit quickly',
+    description:
+      'A concise recruiter brief with current focus areas, selected evidence, experience, working model, and direct links to the CV and professional profiles.',
+    href: '/recruiter-brief',
+    cta: 'Open recruiter brief',
   },
   {
     icon: ShieldCheck,
-    title: 'Critical implementation review',
-    mechanics: 'Typical duration · 3–6 weeks',
-    audience: 'For teams approaching a hard fork, protocol upgrade, or cryptographic rollout.',
-    deliverables:
-      'Independent tests of high-consequence behavior, reproducible findings with severity analysis, and remediation verification.',
+    eyebrow: 'For product & security teams',
+    title: 'Scope an independent review',
+    description:
+      'Conflict-screened differential testing, implementation review, and workshops for critical multi-implementation systems approaching a milestone.',
+    href: '/engagements',
+    cta: 'Explore engagements',
   },
-  {
-    icon: GraduationCap,
-    title: 'Team workshop & advisory',
-    mechanics: '½–1 day session · 1–2 weeks preparation',
-    audience: 'For teams building their own fuzzing or differential-testing capability.',
-    deliverables:
-      'A tailored workshop with practical exercises and reference material, followed by focused office hours.',
-  },
-]
-
-const process = ['Enquiry', 'EF COI check', 'Availability discussion']
-
-// Structured inquiry template (agreed qualification fields, nothing sensitive).
-// A prefilled mailto keeps the site static and the privacy page truthful.
-const inquirySubject = 'Scoped engagement enquiry'
-const inquiryBody = `Organization and role:
-Engagement type (diagnostic / review / workshop / speaking / research):
-Trigger (release, hard fork, audit, standardization, other):
-Desired start window:
-Expected duration or immovable deadline:
-Budget band:
-Problem, in one sentence (nothing confidential):
-Possible conflicts (does this touch Ethereum Foundation responsibilities?):
-`
+] as const
 
 export default function Contact() {
-  const { email, social, cv } = portfolioData.personal
-  const inquiryHref = `mailto:${email}?subject=${encodeURIComponent(
-    inquirySubject,
-  )}&body=${encodeURIComponent(inquiryBody)}`
+  const { email } = portfolioData.personal
 
   return (
     <section id="contact" className="border-t border-line py-24 md:py-28">
       <div className="container-max section-padding">
-        <div>
-          <p className="eyebrow mb-4">08 — Contact</p>
-          <h2 className="section-title">Work with me</h2>
-          <p className="mt-4 max-w-3xl text-lg leading-relaxed text-muted">
-            I&apos;m a security engineer at the Ethereum Foundation. Beyond that, I&apos;m glad to
-            hear about roles and teams working on hard verification problems, research
-            collaboration, conference talks, and podcasts — no formality needed, just email.
-          </p>
+        <p className="eyebrow mb-4">08 — Work with me</p>
+        <h2 className="section-title">Choose the shortest path</h2>
+        <p className="mt-4 max-w-3xl text-lg leading-relaxed text-muted">
+          I&apos;m a security engineer at the Ethereum Foundation. I&apos;m also glad to hear from
+          hiring teams working on hard verification problems and from teams considering a scoped,
+          independent engagement.
+        </p>
 
-          <div className="mt-6 flex flex-wrap items-center gap-x-6 gap-y-3 text-sm">
-            <a href={`mailto:${email}`} className="link-accent inline-flex items-center gap-2">
-              <Mail size={15} />
-              {email}
-            </a>
-            <a
-              href={`https://github.com/${social.github}`}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="link-accent inline-flex items-center gap-2"
+        <div className="mt-10 grid grid-cols-1 gap-6 md:grid-cols-2">
+          {paths.map((path) => (
+            <article
+              key={path.href}
+              className="rounded-xl border border-line bg-surface/50 p-6 md:p-8"
             >
-              <Github size={15} />
-              GitHub
-            </a>
-            <a
-              href={`https://linkedin.com/in/${social.linkedin}`}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="link-accent inline-flex items-center gap-2"
-            >
-              <Linkedin size={15} />
-              LinkedIn
-            </a>
-            <a
-              href={cv}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="link-accent inline-flex items-center gap-2"
-            >
-              <FileDown size={15} />
-              CV (PDF)
-            </a>
-          </div>
-
-          <p className="mt-8 max-w-3xl border-l-2 border-accent pl-4 text-sm leading-relaxed text-muted">
-            My work has been merged upstream by the Nethermind, Erigon, revm, Mbed TLS, and Solidity
-            teams — the review threads are public.
-          </p>
+              <path.icon size={22} className="text-accent" aria-hidden="true" />
+              <p className="eyebrow mt-5 text-accent">{path.eyebrow}</p>
+              <h3 className="mt-3 text-2xl font-semibold text-fg">{path.title}</h3>
+              <p className="mt-4 text-sm leading-relaxed text-muted">{path.description}</p>
+              <Link
+                href={path.href}
+                className="link-accent mt-6 inline-flex items-center gap-2 text-sm font-medium"
+              >
+                <span>{path.cta}</span>
+                <ArrowRight size={15} aria-hidden="true" />
+              </Link>
+            </article>
+          ))}
         </div>
 
-        <div className="mt-16 border-t border-line pt-12">
-          <p className="eyebrow mb-3 text-accent">
-            Independent engagements · availability subject to enquiry
-          </p>
-          <h3 className="text-2xl font-semibold text-fg">Scoped security engagements</h3>
-          <p className="mt-3 max-w-2xl text-muted">
-            For teams that need independent evidence before a release, upgrade, or standardization
-            milestone.
-          </p>
-          <p className="mt-3 max-w-3xl text-sm leading-relaxed text-faint">
-            The ranges below are planning estimates for a focused scope, not availability
-            commitments. Timing is confirmed only after an Ethereum Foundation conflict-of-interest
-            (COI) check and an availability discussion.
-          </p>
-
-          <div className="mt-10 grid grid-cols-1 gap-8 md:grid-cols-3">
-            {engagements.map((item) => (
-              <article key={item.title} className="border-t border-line pt-6">
-                <item.icon size={20} className="mb-4 text-accent" aria-hidden="true" />
-                <h4 className="text-lg font-semibold text-fg">{item.title}</h4>
-                <p className="mt-1 font-mono text-xs text-accent">{item.mechanics}</p>
-                <p className="mt-4 text-sm leading-relaxed text-muted">{item.audience}</p>
-                <p className="mt-3 text-sm leading-relaxed text-muted">
-                  <strong className="font-medium text-fg">You get:</strong> {item.deliverables}
-                </p>
-              </article>
-            ))}
-          </div>
-
-          <div className="mt-10 grid grid-cols-1 gap-x-10 gap-y-6 md:grid-cols-2">
-            <div>
-              <h4 className="eyebrow mb-2">Good fit</h4>
-              <p className="text-sm leading-relaxed text-muted">
-                Multi-implementation systems — L1/L2 clients, cryptographic libraries, compilers,
-                virtual machines — approaching a release, upgrade, audit, or standardization
-                milestone, where a reproducible divergence is worth far more than an opinion.
-              </p>
-            </div>
-            <div>
-              <h4 className="eyebrow mb-2">Poor fit</h4>
-              <p className="text-sm leading-relaxed text-muted">
-                Smart-contract application audits, generic penetration testing, or anything that
-                conflicts with my Ethereum Foundation responsibilities — I run a conflict check
-                before any details are shared.
-              </p>
-            </div>
-          </div>
-
-          <ol className="mt-10 grid grid-cols-1 gap-px border border-line bg-line sm:grid-cols-3">
-            {process.map((step, index) => (
-              <li key={step} className="flex items-center gap-3 bg-bg px-4 py-4">
-                <span className="font-mono text-xs text-accent">
-                  {String(index + 1).padStart(2, '0')}
-                </span>
-                <span className="text-sm font-medium text-fg">{step}</span>
-              </li>
-            ))}
-          </ol>
-
-          <div className="mt-8 flex flex-col items-start gap-4 sm:flex-row sm:items-center">
-            <a href={inquiryHref} className="btn-primary inline-flex items-center gap-2 px-6 py-3">
-              <Mail size={16} />
-              <span>Start a structured enquiry</span>
-            </a>
-            <a
-              href={`https://keybase.io/${social.keybase}/pgp_keys.asc`}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="btn-ghost inline-flex items-center gap-2 px-6 py-3"
-            >
-              <Key size={16} />
-              <span>PGP key for sensitive reports</span>
-            </a>
-          </div>
-
-          <p className="mt-10 max-w-3xl border-l-2 border-accent pl-4 text-sm leading-relaxed text-muted">
-            Do not include vulnerability details, secrets, credentials, or source code in an inquiry
-            — use the PGP key for sensitive reports.
-          </p>
-
-          <p className="mt-8 max-w-3xl text-xs leading-relaxed text-faint">
-            Independent engagements are limited, subject to conflict review, and represent my own
-            views and work — they are not offered, endorsed, or reviewed by the Ethereum Foundation.
-          </p>
+        <div className="mt-8 flex flex-wrap items-center gap-x-6 gap-y-3 text-sm">
+          <a href={`mailto:${email}`} className="link-accent inline-flex items-center gap-2">
+            <Mail size={15} aria-hidden="true" />
+            {email}
+          </a>
+          <span className="text-faint">
+            No formality needed for a first, non-confidential note.
+          </span>
         </div>
       </div>
     </section>

--- a/components/Engagements.tsx
+++ b/components/Engagements.tsx
@@ -1,0 +1,128 @@
+import Link from 'next/link'
+import { ArrowRight, FlaskConical, GraduationCap, Key, Mail, ShieldCheck } from 'lucide-react'
+import portfolioData from '@/data/portfolio.json'
+import { engagementInquiryHref, engagementOffers } from '@/lib/engagements'
+
+const process = ['Enquiry', 'EF COI check', 'Availability discussion']
+
+const offerIcons = {
+  'differential-testing': FlaskConical,
+  'implementation-review': ShieldCheck,
+  workshops: GraduationCap,
+} as const
+
+export default function Engagements() {
+  const { social } = portfolioData.personal
+
+  return (
+    <div>
+      <div className="grid grid-cols-1 gap-8 md:grid-cols-3">
+        {engagementOffers.map((item) => {
+          const Icon = offerIcons[item.slug]
+          return (
+            <article key={item.title} className="rounded-xl border border-line bg-surface/50 p-6">
+              <Icon size={20} className="mb-4 text-accent" aria-hidden="true" />
+              <h2 className="text-xl font-semibold text-fg">{item.title}</h2>
+              <p className="mt-2 font-mono text-xs text-accent">{item.mechanics}</p>
+              <p className="mt-5 text-sm leading-relaxed text-muted">{item.audience}</p>
+              <p className="mt-3 text-sm leading-relaxed text-muted">
+                <strong className="font-medium text-fg">You get:</strong> {item.deliverables}
+              </p>
+              <Link
+                href={`/engagements/${item.slug}/`}
+                className="link-accent mt-5 inline-flex items-center gap-2 text-sm font-medium"
+              >
+                <span>Review the detailed scope</span>
+                <ArrowRight size={14} aria-hidden="true" />
+              </Link>
+            </article>
+          )
+        })}
+      </div>
+
+      <div className="mt-8 rounded-xl border border-line bg-surface/30 p-6 sm:flex sm:items-center sm:justify-between sm:gap-8">
+        <div>
+          <p className="eyebrow text-accent">Specialist review track</p>
+          <h2 className="mt-2 text-xl font-semibold text-fg">Constant-time analysis</h2>
+          <p className="mt-3 max-w-3xl text-sm leading-relaxed text-muted">
+            For cryptographic implementation paths where secret-dependent control flow, arithmetic,
+            or timing behavior needs a bounded, independently evidenced review.
+          </p>
+        </div>
+        <Link
+          href="/engagements/constant-time-analysis/"
+          className="btn-ghost mt-5 inline-flex flex-shrink-0 items-center gap-2 px-5 py-2.5 sm:mt-0"
+        >
+          <span>See the review boundary</span>
+          <ArrowRight size={14} aria-hidden="true" />
+        </Link>
+      </div>
+
+      <div className="mt-12 grid grid-cols-1 gap-x-10 gap-y-8 border-t border-line pt-10 md:grid-cols-2">
+        <div>
+          <h2 className="eyebrow mb-3">Good fit</h2>
+          <p className="text-sm leading-relaxed text-muted">
+            Multi-implementation systems — L1/L2 clients, cryptographic libraries, compilers, and
+            virtual machines — approaching a release, upgrade, audit, or standardization milestone,
+            where a reproducible divergence is worth far more than an opinion.
+          </p>
+        </div>
+        <div>
+          <h2 className="eyebrow mb-3">Poor fit</h2>
+          <p className="text-sm leading-relaxed text-muted">
+            Smart-contract application audits, generic penetration testing, or anything that
+            conflicts with my Ethereum Foundation responsibilities. I run a conflict check before
+            any details are shared.
+          </p>
+        </div>
+      </div>
+
+      <div className="mt-12">
+        <h2 className="text-2xl font-semibold text-fg">What happens next</h2>
+        <ol className="mt-6 grid grid-cols-1 gap-px border border-line bg-line sm:grid-cols-3">
+          {process.map((step, index) => (
+            <li key={step} className="flex items-center gap-3 bg-bg px-4 py-4">
+              <span className="font-mono text-xs text-accent">
+                {String(index + 1).padStart(2, '0')}
+              </span>
+              <span className="text-sm font-medium text-fg">{step}</span>
+            </li>
+          ))}
+        </ol>
+      </div>
+
+      <div className="mt-10 flex flex-col items-start gap-4 sm:flex-row sm:items-center">
+        <a
+          href={engagementInquiryHref}
+          className="btn-primary inline-flex items-center gap-2 px-6 py-3"
+        >
+          <Mail size={16} aria-hidden="true" />
+          <span>Start a structured enquiry</span>
+        </a>
+        <Link href="/#case-studies" className="btn-ghost inline-flex items-center gap-2 px-6 py-3">
+          <span>Review public case studies</span>
+          <ArrowRight size={15} aria-hidden="true" />
+        </Link>
+        <a
+          href={`https://keybase.io/${social.keybase}/pgp_keys.asc`}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="btn-ghost inline-flex items-center gap-2 px-6 py-3"
+        >
+          <Key size={16} aria-hidden="true" />
+          <span>PGP key</span>
+        </a>
+      </div>
+
+      <p className="mt-10 max-w-3xl border-l-2 border-accent pl-4 text-sm leading-relaxed text-muted">
+        Do not include vulnerability details, secrets, credentials, or source code in an enquiry.
+        Use the PGP key for sensitive reports.
+      </p>
+
+      <p className="mt-8 max-w-3xl text-xs leading-relaxed text-faint">
+        Independent engagements are limited, subject to conflict review, and represent my own views
+        and work. They are not offered, endorsed, or reviewed by the Ethereum Foundation.
+      </p>
+    </div>
+  )
+}

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -62,24 +62,24 @@ export default function Footer() {
             <h4 className="eyebrow mb-4">Quick Links</h4>
             <ul className="space-y-2">
               <li>
-                <a href="#case-studies" className="text-muted transition-colors hover:text-fg">
+                <Link href="/#case-studies" className="text-muted transition-colors hover:text-fg">
                   Case Studies
-                </a>
+                </Link>
               </li>
               <li>
-                <a href="#about" className="text-muted transition-colors hover:text-fg">
+                <Link href="/#about" className="text-muted transition-colors hover:text-fg">
                   About
-                </a>
+                </Link>
               </li>
               <li>
-                <a href="#research" className="text-muted transition-colors hover:text-fg">
+                <Link href="/#research" className="text-muted transition-colors hover:text-fg">
                   Research
-                </a>
+                </Link>
               </li>
               <li>
-                <a href="#findings" className="text-muted transition-colors hover:text-fg">
+                <Link href="/#findings" className="text-muted transition-colors hover:text-fg">
                   Selected Findings
-                </a>
+                </Link>
               </li>
               <li>
                 <Link href="/blog" className="text-muted transition-colors hover:text-fg">
@@ -87,19 +87,17 @@ export default function Footer() {
                 </Link>
               </li>
               <li>
-                <a
-                  href={personal.cv}
-                  target="_blank"
-                  rel="noopener noreferrer"
+                <Link
+                  href="/recruiter-brief"
                   className="text-muted transition-colors hover:text-fg"
                 >
-                  CV (PDF)
-                </a>
+                  Recruiter brief
+                </Link>
               </li>
               <li>
-                <a href="#contact" className="text-muted transition-colors hover:text-fg">
-                  Work with me
-                </a>
+                <Link href="/engagements" className="text-muted transition-colors hover:text-fg">
+                  Engagements
+                </Link>
               </li>
             </ul>
           </div>

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -13,14 +13,14 @@ interface NavItem {
 }
 
 const navigation: NavItem[] = [
-  { name: 'Case Studies', href: '#case-studies', id: 'case-studies' },
-  { name: 'About', href: '#about', id: 'about' },
-  { name: 'Research', href: '#research', id: 'research' },
-  { name: 'Findings', href: '#findings', id: 'findings' },
-  { name: 'Talks', href: '#talks', id: 'talks' },
-  { name: 'Papers', href: '#publications', id: 'publications' },
+  { name: 'Case Studies', href: '/#case-studies', id: 'case-studies' },
+  { name: 'About', href: '/#about', id: 'about' },
+  { name: 'Research', href: '/#research', id: 'research' },
+  { name: 'Findings', href: '/#findings', id: 'findings' },
+  { name: 'Talks', href: '/#talks', id: 'talks' },
   { name: 'Blog', href: '/blog' },
-  { name: 'Contact', href: '#contact', id: 'contact' },
+  { name: 'Recruiters', href: '/recruiter-brief' },
+  { name: 'Engagements', href: '/engagements' },
 ]
 
 // Hardcoded rather than imported from portfolio.json so this client component
@@ -173,12 +173,12 @@ export default function Header() {
       <nav aria-label="Primary navigation" className="container-max section-padding">
         <div className="flex h-16 items-center justify-between">
           <div className="flex-shrink-0">
-            <a
-              href="#home"
+            <Link
+              href="/#home"
               className="focus-ring inline-flex min-h-11 items-center rounded-sm text-lg font-semibold tracking-tight text-fg transition-opacity hover:opacity-80 xl:text-xl"
             >
               Bhargava Shastry
-            </a>
+            </Link>
           </div>
 
           <div className="hidden lg:block">

--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -148,9 +148,13 @@ export default function Hero({ latestPost, publicationsCount }: HeroProps) {
             </h1>
 
             <p className="mt-7 max-w-2xl text-xl leading-relaxed text-fg sm:text-2xl">
+              I find consensus and implementation bugs before they become incidents.
+            </p>
+
+            <p className="mt-4 max-w-2xl text-base leading-relaxed text-muted sm:text-lg">
               I run independent implementations against each other — Ethereum clients, post-quantum
-              cryptography libraries, compilers — and turn every disagreement into a reproducible
-              bug report.
+              cryptography libraries, and compilers — and turn every disagreement into reproducible
+              evidence and an upstream fix.
             </p>
 
             <p className="mt-6 max-w-2xl text-sm leading-relaxed text-muted sm:text-base">
@@ -235,17 +239,12 @@ export default function Hero({ latestPost, publicationsCount }: HeroProps) {
           <a href="#case-studies" className="btn-primary px-6 py-3">
             See case studies
           </a>
-          <a href="#contact" className="btn-ghost px-6 py-3">
-            Start a conversation
-          </a>
-          <a
-            href={portfolioData.personal.cv}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="btn-ghost px-6 py-3"
-          >
-            Download CV (PDF)
-          </a>
+          <Link href="/recruiter-brief" className="btn-ghost px-6 py-3">
+            For hiring teams
+          </Link>
+          <Link href="/engagements" className="btn-ghost px-6 py-3">
+            Engagement options
+          </Link>
         </div>
 
         {/* Distinct destination from the "See case studies" CTA above: this

--- a/docs/distribution-playbook.md
+++ b/docs/distribution-playbook.md
@@ -1,0 +1,219 @@
+# Distribution Playbook
+
+This playbook turns each substantial public artifact into a small, repeatable distribution cycle.
+It is intentionally selective: the goal is qualified conversations with protocol/security teams
+and hiring teams, not maximum undifferentiated traffic.
+
+Last channel-policy review: 2026-07-21.
+
+## Expert verdict on the distribution advice
+
+### Keep
+
+- Distribution is the next likely constraint once the dedicated recruiter and engagement routes are
+  live. In this niche, trusted people and project communities often precede direct website visits.
+- Publish the canonical article on this site, then write channel-native summaries that link to it.
+- When a fix or disclosure is public, tell the short engineering story and link both the upstream
+  artifact and the relevant case study.
+- Put the site one click away from GitHub, LinkedIn, X, speaker bios, and research-identity pages
+  that actually support an external URL.
+- Use the site's problem-language — differential testing, Ethereum client security, implementation
+  review, and constant-time analysis — consistently in profiles and pitches.
+
+### Modify
+
+- Do not send every article to every channel. Choose channels by subject and community fit.
+- Treat Hacker News and Lobsters as communities, not traffic faucets. Neither placement nor a front
+  page result is predictable. Use the original title and source, participate personally, and never
+  request votes.
+- Pitch newsletters selectively; “syndication” is not assumed. A short, relevant note with one
+  strong public artifact is better than a generic request to feature the site.
+- Treat commercial search phrases as hypotheses until Search Console exposes impressions and
+  queries. Publish only pages that can stand on first-hand evidence; do not manufacture keyword
+  variants.
+- Prefer summaries with a canonical link over automatic full-text cross-posting. This keeps one
+  source of truth and makes updates, corrections, and evidence links easier to maintain.
+
+### Reject or defer
+
+- Do not claim that a particular post is likely to reach the Hacker News front page or that one
+  newsletter mention will outperform months of search work. Those are outcomes to measure, not
+  promises.
+- Do not submit repeatedly to Lobsters without being a genuine participant. Its published rule of
+  thumb keeps self-promotion below one quarter of a user's stories and comments.
+- Do not assume an editable website field exists on every arXiv author surface. Verify the exact
+  account capability; otherwise keep the site on ORCID and Google Scholar, which are intended as
+  researcher profiles.
+- Do not add tracking scripts or a new analytics vendor until the privacy and measurement tradeoff
+  is an explicit owner decision.
+
+## One-time profile alignment
+
+The GitHub profile already includes `bshastry.github.io`; keep it. Consider replacing the generic
+bio with:
+
+> Differential testing for critical systems · Ethereum clients · cryptographic implementations · compilers
+
+Suggested LinkedIn headline:
+
+> Security Engineer, Ethereum Foundation | Differential testing for critical systems | Protocol, compiler & cryptographic implementation security
+
+Suggested X bio:
+
+> Differential testing for critical systems: Ethereum clients, cryptographic libraries, and compilers. Security Engineer @ethereum.
+
+Set the X website field to `https://bshastry.github.io/`. On LinkedIn, add these in the Featured
+section if the account tier and current interface expose external-link features:
+
+1. `https://bshastry.github.io/` — evidence-led portfolio
+2. `https://bshastry.github.io/blog/trust-no-single-witness/` — concise testing philosophy
+3. `https://bshastry.github.io/recruiter-brief/` — hiring-team brief
+
+Suggested short speaker bio:
+
+> Bhargava Shastry is a Security Engineer at the Ethereum Foundation working on differential testing, hard-fork readiness, and vulnerability triage across critical implementations. His public work spans Ethereum clients, compilers, cryptographic libraries, and side-channel analysis. Evidence and writing: https://bshastry.github.io/
+
+Re-check the website URL in conference profiles whenever a new event bio is submitted. Use the same
+canonical `https://` URL everywhere.
+
+## Channel-fit matrix
+
+| Artifact                                 | Primary channels                        | Conditional channels              | Why                                                    |
+| ---------------------------------------- | --------------------------------------- | --------------------------------- | ------------------------------------------------------ |
+| Ethereum client or hard-fork result      | X, LinkedIn, relevant project community | Hacker News, New Week in Ethereum | Strong maintainer and protocol-engineering relevance   |
+| Reusable fuzzing/oracle technique        | Hacker News, X, LinkedIn                | Lobsters, tl;dr sec               | Broad technical lesson beyond one project              |
+| Public security advisory or upstream fix | Project community, X, LinkedIn          | tl;dr sec, Hacker News            | Concrete evidence, but only after disclosure is public |
+| Cryptographic implementation analysis    | X, LinkedIn, tl;dr sec                  | Hacker News, Lobsters             | Security depth with a reusable engineering takeaway    |
+| Career/recruiter update                  | LinkedIn                                | X                                 | High hiring relevance, low fit for link aggregators    |
+
+“Conditional” means submit only when the artifact is independently useful to that community and the
+author can participate in the resulting discussion.
+
+## Per-article distribution packet
+
+Before posting, write five facts in plain language:
+
+1. The problem or decision the article addresses.
+2. The surprising or counterintuitive claim.
+3. The public evidence supporting it.
+4. The limitation or blind spot.
+5. The canonical URL.
+
+Use those facts to create channel-native summaries. Do not copy the same promotional paragraph
+everywhere.
+
+### X structure
+
+Use three to six posts:
+
+1. State the technical tension or result without throat-clearing.
+2. Explain the method in one concrete example.
+3. Link the strongest public artifact or upstream fix.
+4. Name the limitation or what the test cannot establish.
+5. Link the canonical article and, when genuinely relevant, tag the project once.
+
+Keep the website in the profile website field and pin the strongest current article or case study.
+
+### LinkedIn structure
+
+Use roughly 150–300 words:
+
+- Two sentences on the engineering stakes.
+- One short paragraph on the method.
+- One concrete result with an upstream evidence link.
+- One sentence on the limitation or transferable lesson.
+- One canonical link to the article or relevant audience page.
+
+For hiring reach, alternate technical posts with occasional synthesis posts that make the role fit
+explicit. Avoid turning every technical result into a job-seeking post.
+
+### Hacker News submission
+
+- Submit the canonical URL and the original, non-editorialized title.
+- Submit only when the article would be interesting without the service offering attached.
+- Do not ask colleagues or followers for votes, comments, or submissions.
+- Do not use the account primarily for promotion.
+- Write any discussion comments personally. The current HN guidelines disallow generated or
+  AI-edited comments.
+
+### Lobsters submission
+
+- Participate before promoting your own work; the site is invitation-based.
+- Keep self-promotion below the site's published one-quarter rule of thumb across stories and
+  comments.
+- Submit only if the story fits an available technical tag and offers a durable programming or
+  systems lesson.
+- Do not add tracking parameters; Lobsters removes them and bans marketing-analytics domains.
+
+### Newsletter pitch
+
+Send one tailored note, not a bulk pitch:
+
+```text
+Subject: Possible item — [specific technical result]
+
+I published a first-hand account of [problem] in [system/project].
+The reusable takeaway is [one sentence], backed by [upstream fix/advisory/harness].
+It may fit your [specific section/audience]: [canonical URL]
+No action needed if it is outside the issue's scope.
+```
+
+For Ethereum-client and hard-fork work, consider New Week in Ethereum. For broadly reusable
+security tooling, implementation analysis, or a public disclosure, consider tl;dr sec. Verify the
+current editor/contact route before every pitch.
+
+### Upstream-fix follow-up
+
+Publish only after the fix or disclosure is public. A useful 200-word structure is:
+
+1. What behavior disagreed or leaked.
+2. Why the impact was non-obvious.
+3. How the input or path was minimized.
+4. What changed upstream.
+5. What regression test or review lesson remains.
+
+Link the exact pull request, advisory, or changelog entry. Tag maintainers only when their project is
+the direct subject and the public artifact is ready for discussion.
+
+## Six-week operating cadence
+
+- Week 0: align profile copy and links; deploy the audience routes and service-detail pages.
+- Every substantial article: publish on-site, then distribute to one or two primary channels.
+- Within seven days: make at most one community submission and one newsletter pitch when the fit is
+  strong.
+- When an upstream result becomes public: publish the short follow-up and add it to the relevant
+  case study or findings ledger.
+- Every two weeks: spend more time responding to other people's technical work than promoting your
+  own.
+- At six weeks: review evidence and keep only the channels producing qualified conversations,
+  maintainer engagement, newsletter placements, or relevant search impressions.
+
+## Measurement without a tracking script
+
+Record these manually in a small private spreadsheet:
+
+- Date, artifact, and canonical URL
+- Channels used and direct post/submission URLs
+- Maintainer replies or reshares
+- Newsletter placements
+- Qualified engagement enquiries
+- Relevant recruiter conversations
+- “How did you find this page?” answers from email enquiries
+- Search Console clicks, impressions, average position, and query themes by landing page
+
+Do not optimize for raw impressions. The useful leading indicator is public engagement from the
+people who maintain, secure, or hire for the systems covered. The useful lagging indicator is a
+qualified conversation with a clear source.
+
+## Official references
+
+- Hacker News guidelines: <https://news.ycombinator.com/newsguidelines.html>
+- Lobsters guidelines and invitation model: <https://lobste.rs/about>
+- GitHub profile setup: <https://docs.github.com/en/get-started/start-your-journey/setting-up-your-profile>
+- LinkedIn Featured work samples: <https://www.linkedin.com/help/linkedin/answer/a550399/manage-featured-samples-of-your-work-on-your-linkedin-profile>
+- X profile customization: <https://help.x.com/articles/166743>
+- Google people-first content guidance: <https://developers.google.com/search/docs/fundamentals/creating-helpful-content>
+- Google title guidance: <https://developers.google.com/search/docs/appearance/title-link>
+- Search Console query reporting: <https://developers.google.com/webmaster-tools/v1/how-tos/search_analytics>
+- New Week in Ethereum contact page: <https://wie.ercref.org/>
+- tl;dr sec: <https://tldrsec.com/>

--- a/lib/engagements.ts
+++ b/lib/engagements.ts
@@ -1,0 +1,336 @@
+import portfolioData from '@/data/portfolio.json'
+
+export const engagementOffers = [
+  {
+    slug: 'differential-testing',
+    title: 'Differential-testing diagnostic',
+    mechanics: 'Typical duration · 1–2 weeks',
+    audience: 'For teams that suspect cross-implementation or oracle risk.',
+    deliverables:
+      'A divergence and threat model, a target matrix, a harness and coverage roadmap, and a prioritized-risk debrief — the same artifact structure as the public case studies.',
+  },
+  {
+    slug: 'implementation-review',
+    title: 'Critical implementation review',
+    mechanics: 'Typical duration · 3–6 weeks',
+    audience: 'For teams approaching a hard fork, protocol upgrade, or cryptographic rollout.',
+    deliverables:
+      'Independent tests of high-consequence behavior, reproducible findings with severity analysis, and remediation verification.',
+  },
+  {
+    slug: 'workshops',
+    title: 'Team workshop & advisory',
+    mechanics: '½–1 day session · 1–2 weeks preparation',
+    audience: 'For teams building their own fuzzing or differential-testing capability.',
+    deliverables:
+      'A tailored workshop with practical exercises and reference material, followed by focused office hours.',
+  },
+] as const
+
+export interface EngagementGuide {
+  slug: string
+  label: string
+  eyebrow: string
+  metadataTitle: string
+  metadataDescription: string
+  heading: string
+  lead: string
+  serviceType: string
+  audience: string
+  situations: readonly string[]
+  phases: readonly { title: string; description: string }[]
+  outputs: readonly string[]
+  boundary: string
+  evidence: readonly { label: string; href: string; description: string }[]
+}
+
+export const engagementGuides: readonly EngagementGuide[] = [
+  {
+    slug: 'differential-testing',
+    label: 'Differential-testing diagnostic',
+    eyebrow: 'Differential fuzzing · oracle design',
+    metadataTitle: 'Differential Fuzzing & Testing for Critical Systems',
+    metadataDescription:
+      'Scoped differential fuzzing and testing for Ethereum clients, cryptographic libraries, compilers, and other multi-implementation systems.',
+    heading: 'Differential testing for systems with no single trusted oracle',
+    lead: 'A focused diagnostic for teams that need to turn disagreement between independent implementations into minimized, reproducible evidence.',
+    serviceType: 'Differential fuzzing and testing diagnostic',
+    audience:
+      'Engineering and security teams responsible for multi-implementation protocols, runtimes, compilers, or cryptographic libraries.',
+    situations: [
+      'Independent implementations must agree, but no single implementation is trustworthy enough to serve as ground truth.',
+      'A protocol, standard, or hard-fork change creates new behavior that must be compared before release.',
+      'An existing fuzzer reaches code but its oracle, corpus, or triage process produces weak signal.',
+      'A suspected divergence needs to be reproduced, minimized, and translated into an actionable upstream report.',
+    ],
+    phases: [
+      {
+        title: 'Model the contract',
+        description:
+          'Identify the shared semantic boundary, the independent witnesses, and the disagreements that would matter operationally.',
+      },
+      {
+        title: 'Design the harness and oracles',
+        description:
+          'Map inputs, normalization, comparison points, coverage, and failure modes without appointing one implementation as infallible.',
+      },
+      {
+        title: 'Run and triage a focused campaign',
+        description:
+          'Exercise the highest-value paths, minimize divergences, and separate implementation defects from harness or specification ambiguity.',
+      },
+      {
+        title: 'Hand off reproducible evidence',
+        description:
+          'Deliver prioritized cases, root-cause direction, regression-test recommendations, and a roadmap for the next campaign.',
+      },
+    ],
+    outputs: [
+      'Divergence and threat model',
+      'Target and oracle matrix',
+      'Harness, corpus, and coverage roadmap',
+      'Minimized reproducers and prioritized-risk debrief',
+    ],
+    boundary:
+      'This is not a generic penetration test or a smart-contract application audit. It is a scoped review of agreement and correctness at a shared implementation boundary.',
+    evidence: [
+      {
+        label: 'Ethereum client case study',
+        href: '/#client-divergence',
+        description: 'Cross-client divergences reduced to upstream fixes and regression tests.',
+      },
+      {
+        label: 'Trust No Single Witness',
+        href: '/blog/trust-no-single-witness/',
+        description: 'The testing philosophy and its practical limits across critical systems.',
+      },
+      {
+        label: 'Post-quantum case study',
+        href: '/#post-quantum',
+        description: 'Cross-implementation validation of ML-KEM and ML-DSA implementations.',
+      },
+    ],
+  },
+  {
+    slug: 'implementation-review',
+    label: 'Critical implementation review',
+    eyebrow: 'Protocol security · pre-release review',
+    metadataTitle: 'Ethereum Client & Critical Implementation Security Review',
+    metadataDescription:
+      'Independent security review for Ethereum clients and critical protocol or cryptographic implementations before releases, upgrades, and rollouts.',
+    heading: 'Independent implementation review before a high-consequence milestone',
+    lead: 'A bounded review for teams approaching a client release, hard fork, protocol upgrade, cryptographic rollout, or standardization decision.',
+    serviceType: 'Critical protocol and implementation security review',
+    audience:
+      'Maintainers and security teams shipping protocol clients, virtual machines, compilers, and cryptographic implementations.',
+    situations: [
+      'A release or upgrade changes consensus-critical, parser, arithmetic, state-transition, or interoperability behavior.',
+      'The implementation has strong conventional tests but needs independent adversarial or cross-implementation validation.',
+      'A specification change must be checked against executable behavior across more than one codebase.',
+      'A reported issue needs severity analysis, blast-radius testing, or remediation verification.',
+    ],
+    phases: [
+      {
+        title: 'Fix the review boundary',
+        description:
+          'Agree on the milestone, high-consequence behaviors, relevant implementations, exclusions, and evidence needed for a decision.',
+      },
+      {
+        title: 'Build independent checks',
+        description:
+          'Combine differential tests, properties, targeted harnesses, specification witnesses, and manual analysis where each adds distinct signal.',
+      },
+      {
+        title: 'Reproduce and assess findings',
+        description:
+          'Minimize failures, test cross-client or cross-version impact, and distinguish local defects from protocol-level risk.',
+      },
+      {
+        title: 'Verify remediation',
+        description:
+          'Retest fixes, recommend regression coverage, and document residual assumptions and blind spots.',
+      },
+    ],
+    outputs: [
+      'Scope and high-consequence behavior map',
+      'Independent tests and reproducible findings',
+      'Severity and blast-radius analysis',
+      'Remediation verification and residual-risk debrief',
+    ],
+    boundary:
+      'If you are searching for an “Ethereum client audit,” this is the relevant scope: client and protocol implementation behavior, not application-level Solidity contracts. The outcome is independent evidence, not a blanket assurance claim.',
+    evidence: [
+      {
+        label: 'Ethereum client case study',
+        href: '/#client-divergence',
+        description: 'Public examples of consensus-sensitive fixes across revm and Nethermind.',
+      },
+      {
+        label: 'Security findings ledger',
+        href: '/findings/',
+        description: 'Upstream fixes, coordinated disclosures, and security-relevant bugs.',
+      },
+      {
+        label: 'Research archive',
+        href: '/research/',
+        description: 'Protocol, compiler, cryptographic, and fuzzing work with source artifacts.',
+      },
+    ],
+  },
+  {
+    slug: 'constant-time-analysis',
+    label: 'Constant-time analysis track',
+    eyebrow: 'Cryptographic code · side-channel review',
+    metadataTitle: 'Constant-Time Analysis & Cryptographic Implementation Review',
+    metadataDescription:
+      'Scoped constant-time analysis and side-channel review for high-consequence cryptographic implementation paths, backed by public disclosure evidence.',
+    heading: 'Constant-time analysis for cryptographic implementation paths',
+    lead: 'A specialist track within a critical implementation review for teams concerned about secret-dependent control flow, arithmetic, or observable timing behavior.',
+    serviceType: 'Constant-time analysis and cryptographic implementation review',
+    audience:
+      'Maintainers and security teams responsible for cryptographic libraries, embedded TLS stacks, and implementations of cryptographic standards.',
+    situations: [
+      'Secret material reaches arithmetic, reduction, parsing, rejection, or key-generation paths whose timing properties are unclear.',
+      'A constant-time claim needs independent scrutiny across source, compiler output, target architecture, or runtime behavior.',
+      'Multiple implementations are expected to be functionally equivalent but may differ in timing or memory-access behavior.',
+      'A suspected side channel needs a reproducible path, impact analysis, and coordinated remediation.',
+    ],
+    phases: [
+      {
+        title: 'Map secrets to observables',
+        description:
+          'Identify secret-bearing inputs, sensitive operations, target platforms, attacker observations, and the exact constant-time claim under review.',
+      },
+      {
+        title: 'Trace high-risk paths',
+        description:
+          'Review control flow, arithmetic, compiler effects, and implementation choices that can make behavior depend on secret data.',
+      },
+      {
+        title: 'Construct independent checks',
+        description:
+          'Use source analysis, targeted experiments, and differential or constant-time checks appropriate to the stated threat model.',
+      },
+      {
+        title: 'Report and retest',
+        description:
+          'Provide reproducible evidence, coordinate sensitive disclosure where needed, and verify the relevant remediation paths.',
+      },
+    ],
+    outputs: [
+      'Threat model and constant-time claim boundary',
+      'Secret-to-observable path analysis',
+      'Reproducible findings or documented negative results',
+      'Remediation verification and residual blind spots',
+    ],
+    boundary:
+      'A scoped constant-time review is not a formal proof that an entire library is side-channel free. The claim is limited to the reviewed paths, builds, platforms, and attacker observations.',
+    evidence: [
+      {
+        label: 'Mbed TLS timing case study',
+        href: '/#mbedtls-timing',
+        description: 'Secret-dependent timing paths reported and remediated through disclosure.',
+      },
+      {
+        label: 'Security findings ledger',
+        href: '/findings/',
+        description: 'The linked advisory and upstream change evidence.',
+      },
+      {
+        label: 'ML-KEM testing series',
+        href: '/blog/cross-checking-post-quantum-kem/',
+        description: 'Functional and constant-time oracle design across independent libraries.',
+      },
+    ],
+  },
+  {
+    slug: 'workshops',
+    label: 'Differential-testing workshop & advisory',
+    eyebrow: 'Team capability · practical workshop',
+    metadataTitle: 'Differential Fuzzing Workshop & Team Advisory',
+    metadataDescription:
+      'A tailored differential fuzzing and test-oracle workshop for teams building repeatable security testing capability around critical systems.',
+    heading: 'Build a differential-testing capability your team can keep running',
+    lead: 'A practical workshop and focused advisory package built around your system, current harnesses, and the decisions your testing must support.',
+    serviceType: 'Differential fuzzing workshop and team advisory',
+    audience:
+      'Security, protocol, compiler, runtime, and cryptographic engineering teams establishing or improving an internal testing program.',
+    situations: [
+      'The team understands fuzzing but needs a stronger model for oracles, witnesses, and correlated blind spots.',
+      'A prototype harness exists but coverage, corpus design, minimization, or triage is not yet operationally useful.',
+      'Maintainers need a shared method for translating disagreements into reproducible reports and regression tests.',
+      'A new testing initiative needs a bounded roadmap rather than an open-ended tooling project.',
+    ],
+    phases: [
+      {
+        title: 'Pre-workshop intake',
+        description:
+          'Review the system boundary, existing tests, representative artifacts, team goals, and anything that must remain out of scope.',
+      },
+      {
+        title: 'Tailor practical exercises',
+        description:
+          'Build examples around the team’s languages, implementations, failure modes, and available test oracles.',
+      },
+      {
+        title: 'Run the working session',
+        description:
+          'Cover threat modeling, witness independence, harness architecture, coverage, minimization, triage, and honest negative-result reporting.',
+      },
+      {
+        title: 'Turn learning into a roadmap',
+        description:
+          'Close with concrete next experiments, ownership, success criteria, and focused office hours for the first implementation steps.',
+      },
+    ],
+    outputs: [
+      'Tailored workshop and practical exercises',
+      'Reference material for the team',
+      'Prioritized harness and campaign roadmap',
+      'Focused follow-up office hours',
+    ],
+    boundary:
+      'The workshop is not a certification or a substitute for reviewing the implementation itself. Its purpose is to leave the team with a technically honest method and a runnable next step.',
+    evidence: [
+      {
+        label: 'Trust No Single Witness',
+        href: '/blog/trust-no-single-witness/',
+        description: 'A concise foundation for reasoning about fallible test oracles.',
+      },
+      {
+        label: 'Testing-oracle essay',
+        href: '/blog/testing-oracles/',
+        description: 'Why coverage is not enough when the mechanism judging correctness is weak.',
+      },
+      {
+        label: 'Talks and teaching material',
+        href: '/#talks',
+        description:
+          'Public presentations on fuzzing, compilers, clients, and vulnerability research.',
+      },
+    ],
+  },
+]
+
+export function getEngagementGuide(slug: string): EngagementGuide | undefined {
+  return engagementGuides.find((guide) => guide.slug === slug)
+}
+
+const inquiryBody = (engagementType: string) => `Organization and role:
+Engagement type: ${engagementType}
+Trigger (release, hard fork, audit, standardization, other):
+Desired start window:
+Expected duration or immovable deadline:
+Budget band:
+Problem, in one sentence (nothing confidential):
+Possible conflicts (does this touch Ethereum Foundation responsibilities?):
+How did you find this page?:
+`
+
+export function getEngagementInquiryHref(engagementType = 'Not sure yet') {
+  return `mailto:${portfolioData.personal.email}?subject=${encodeURIComponent(
+    'Scoped engagement enquiry',
+  )}&body=${encodeURIComponent(inquiryBody(engagementType))}`
+}
+
+export const engagementInquiryHref = getEngagementInquiryHref()


### PR DESCRIPTION
## Summary

Validates and applies the cumulative website-growth patch (base commit `117eaca`). The patch, implementation plan, and prompt were cross-checked against the repository before applying; the patch applied cleanly and is applied **as-is** — no modifications were needed.

### What's included

- **New audience routes:** `/recruiter-brief/` (hiring teams) and `/engagements/` (product & security teams), each with unique metadata, canonical URLs, and JSON-LD.
- **Four statically generated service-detail routes** under `/engagements/` — differential-testing, implementation-review, constant-time-analysis, workshops — backed by a shared typed data module (`lib/engagements.ts`) so visible copy and structured data cannot drift.
- **Evidence deep-links:** stable, scroll-offset-aware anchors on homepage case studies (`client-divergence`, `mbedtls-timing`, `post-quantum`); all three IDs verified against `data/portfolio.json`.
- **Blog share panel:** copy-canonical-link with visible success feedback plus X, LinkedIn, and Hacker News actions. Verified in built HTML: canonical URLs, original titles, zero tracking parameters.
- **Privacy-conscious attribution:** "How did you find this page?" added to engagement and recruiter mailto templates — no analytics vendor, script, or cookie added.
- **Navigation:** root-qualified homepage fragment links in header/footer so anchors resolve from nested routes. Header scrollspy keys off section IDs, not hrefs, so highlighting is unaffected.
- **`docs/distribution-playbook.md`:** channel-fit matrix, HN/Lobsters policy constraints, six-week cadence, manual measurement loop.
- **Indexing:** sitemap entries for all six new routes; README architecture notes updated.

### Deliberate routing tradeoffs (from the plan, preserved as-is)

- Header nav swaps "Papers" and "Contact" for "Recruiters" and "Engagements" (same item count — no overflow; both sections remain on the homepage).
- CV download moves from Hero/Footer to the recruiter brief.

### Review focus areas (all clear)

- **No private info:** scanned built pages and docs for compensation, financial goals, target employers, relocation, work-authorization content — none present. "Budget band:" in the enquiry template pre-exists and asks about the client's budget.
- **Guardrails preserved:** EF conflict-of-interest review, independent-work disclaimer, sensitive-data warning, PGP route, and "Remote"/selective-availability language all present on new pages.
- **No dependency changes:** lockfile untouched; no analytics, forms, or backends.

### Verification

- `npm ci`, `npm run check` (typecheck + lint + format) — pass
- `npm run build` — 75 static pages, all four `[slug]` routes SSG-generated
- `npm run check:links` — 67 pages, 1,124 internal references, no broken links
- `git diff --check` — clean
- Built HTML inspected: sitemap contains all six new URLs, `Service` JSON-LD present, mailto attribution present, share links canonical with no tracking parameters

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D4pi3DnzJ8Sr5FmqwVcJhS

---
_Generated by [Claude Code](https://claude.ai/code/session_01D4pi3DnzJ8Sr5FmqwVcJhS)_