### PR TITLE
Add blst Rust-bindings memory-safety hardening finding

### DIFF
--- a/components/DisclosureLedger.tsx
+++ b/components/DisclosureLedger.tsx
@@ -112,10 +112,10 @@ export default function DisclosureLedger() {
                 A CVE is the public vulnerability record. A vendor or distributor may separately
                 publish an advisory, and a public finding may instead be documented in a patch,
                 issue, or paper without receiving a CVE. This ledger uses “CVE-backed disclosure”
-                for the {disclosureSummary.cves} assigned records and keeps the non-CVE pinctrl fix
-                separate. Solidity’s own term is “known security-relevant compiler bugs”; those SOL
-                records are shown in a separate ledger below. Severity is never inferred from an
-                identifier.
+                for the {disclosureSummary.cves} assigned records and keeps the{' '}
+                {disclosureSummary.additionalPublicFindings} non-CVE hardening findings separate.
+                Solidity’s own term is “known security-relevant compiler bugs”; those SOL records
+                are shown in a separate ledger below. Severity is never inferred from an identifier.
               </p>
             </div>
           </div>
@@ -307,33 +307,51 @@ export default function DisclosureLedger() {
         <div className="mb-6 border-b border-line pb-5">
           <p className="eyebrow mb-2">Public, without a CVE</p>
           <h2 id="additional-findings-heading" className="text-2xl font-semibold text-fg">
-            Additional finding
+            Additional findings
           </h2>
         </div>
 
-        {additionalPublicFindings.map((finding) => (
-          <article
-            key={finding.url}
-            className="grid gap-3 border-y border-line py-5 md:grid-cols-[12rem_minmax(0,1fr)] md:gap-6"
-          >
-            <div>
-              <p className="font-mono text-sm text-faint">{finding.date}</p>
-              <p className="mt-1 text-sm font-medium text-accent">{finding.project}</p>
-            </div>
-            <div>
-              <a
-                href={finding.url}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="inline-flex items-center gap-1.5 font-semibold text-fg transition-colors hover:text-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
-              >
-                {finding.title}
-                <ExternalLink size={14} aria-hidden="true" />
-              </a>
-              <p className="mt-2 text-sm leading-relaxed text-muted">{finding.description}</p>
-            </div>
-          </article>
-        ))}
+        <div className="divide-y divide-line border-y border-line">
+          {additionalPublicFindings.map((finding) => (
+            <article
+              key={finding.url}
+              className="grid gap-3 py-5 md:grid-cols-[12rem_minmax(0,1fr)] md:gap-6"
+            >
+              <div>
+                <p className="font-mono text-sm text-faint">{finding.date}</p>
+                <p className="mt-1 text-sm font-medium text-accent">{finding.project}</p>
+              </div>
+              <div>
+                <a
+                  href={finding.url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex items-center gap-1.5 font-semibold text-fg transition-colors hover:text-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+                >
+                  {finding.title}
+                  <ExternalLink size={14} aria-hidden="true" />
+                </a>
+                <p className="mt-2 text-sm leading-relaxed text-muted">{finding.description}</p>
+                {finding.links && finding.links.length > 0 && (
+                  <div className="mt-3 flex flex-wrap gap-x-5 gap-y-2">
+                    {finding.links.map((link) => (
+                      <a
+                        key={link.url}
+                        href={link.url}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="link-accent inline-flex items-center gap-1.5 text-sm"
+                      >
+                        {link.label}
+                        <ExternalLink size={13} aria-hidden="true" />
+                      </a>
+                    ))}
+                  </div>
+                )}
+              </div>
+            </article>
+          ))}
+        </div>
       </section>
     </>
   )

--- a/data/portfolio.json
+++ b/data/portfolio.json
@@ -373,6 +373,14 @@
       "featured": true
     },
     {
+      "title": "Two safe-Rust memory-safety issues hardened in blst's Rust bindings",
+      "description": "Reported a DST use-after-free in Pairing and out-of-bounds scalar reads via unchecked nbits in blst 0.3.16, both reachable from safe Rust; hardened upstream with a DST lifetime bound and a scalar-length check. Not a security issue — the parameters are fixed at application design time.",
+      "project": "supranational/blst",
+      "type": "Fixed upstream",
+      "date": "Jul 2026",
+      "url": "https://github.com/supranational/blst/commit/1172c188cfcc059121b024a2010884700402baf9"
+    },
+    {
       "title": "Variable-time division on Mbed TLS RSA prime-generation path",
       "description": "Reported a variable-time DIV in mbedtls_mpi_mod_int reachable from RSA prime generation with secret data; fixed in Mbed TLS 3.6.7 and TF-PSA-Crypto.",
       "project": "Mbed-TLS/TF-PSA-Crypto",

--- a/lib/disclosures.ts
+++ b/lib/disclosures.ts
@@ -182,7 +182,34 @@ export const disclosureGroups: DisclosureGroup[] = [
   },
 ]
 
-export const additionalPublicFindings = [
+export interface PublicFinding {
+  project: string
+  date: string
+  title: string
+  description: string
+  url: string
+  links?: { label: string; url: string }[]
+}
+
+export const additionalPublicFindings: PublicFinding[] = [
+  {
+    project: 'Supranational blst',
+    date: 'Jul 2026',
+    title: 'Two safe-Rust memory-safety issues in the blst Rust bindings',
+    description:
+      'Privately reported two issues in the blst 0.3.16 Rust bindings, both reachable from safe Rust and reproduced under AddressSanitizer: Pairing stored a raw pointer to a borrowed DST slice and could read freed memory after the slice was dropped, and Pairing::mul_n_aggregate (and the high-level verify_multiple_aggregate_signatures) accepted an nbits value unchecked against the scalar slice length, allowing out-of-bounds reads. The maintainer fixed both — a DST lifetime bound on Pairing and a scalar-length check that panics on mismatch. Reporter and maintainer agreed these are hardening fixes rather than a security issue: the affected parameters are fixed at application design time and not attacker-controlled, and downstream use in Lighthouse v8.2.0 was checked and not affected.',
+    url: 'https://github.com/supranational/blst/commit/1172c188cfcc059121b024a2010884700402baf9',
+    links: [
+      {
+        label: 'Fix: bind DST lifetime to Pairing',
+        url: 'https://github.com/supranational/blst/commit/1172c188cfcc059121b024a2010884700402baf9',
+      },
+      {
+        label: 'Fix: harden Pairing.mul_n_aggregate interface',
+        url: 'https://github.com/supranational/blst/commit/96a46e6ca7360713d9bb1fb78469c28b3c043099',
+      },
+    ],
+  },
   {
     project: 'Open vSwitch / OVN',
     date: 'May 2017',


### PR DESCRIPTION
Records the two safe-Rust memory-safety issues privately reported to Supranational in the `blst` 0.3.16 Rust bindings, now fixed upstream.

## What's included

- **`lib/disclosures.ts`** — new entry in `additionalPublicFindings` (the non-CVE ledger) describing both issues factually:
  - `Pairing` stored a raw pointer to a borrowed DST slice and could read freed memory after the slice was dropped (heap use-after-free under ASan).
  - `Pairing::mul_n_aggregate` / `verify_multiple_aggregate_signatures` accepted `nbits`/`rand_bits` unchecked against the scalar slice length (out-of-bounds reads under ASan).

  The entry links both upstream fix commits and states explicitly that these are **hardening fixes, not a security issue** — the affected parameters are fixed at application design time and not attacker-controlled, and downstream use in Lighthouse v8.2.0 was checked and not affected. A small typed `PublicFinding` interface with an optional `links` array was added so a finding can cite multiple fix commits.
- **`components/DisclosureLedger.tsx`** — renders the optional fix-commit links, pluralizes the "Additional findings" heading, and derives the non-CVE count in the classification note from the data instead of hardcoding the pinctrl reference.
- **`data/portfolio.json`** — a "Fixed upstream" card in the homepage Selected Findings grid, with the same not-a-security-issue framing.

Fix commits referenced:
- https://github.com/supranational/blst/commit/1172c188cfcc059121b024a2010884700402baf9 (bind DST lifetime to `Pairing`)
- https://github.com/supranational/blst/commit/96a46e6ca7360713d9bb1fb78469c28b3c043099 (harden `Pairing.mul_n_aggregate` interface)

`npm run check` (typecheck, lint, prettier) and `npm run build` both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01249B5NHXe2AyMKpdhormZf

---
_Generated by [Claude Code](https://claude.ai/code/session_01249B5NHXe2AyMKpdhormZf)_