### PR TITLE
Add signed machine-readable professional claims

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,5 +17,6 @@ jobs:
       - run: npm run typecheck
       - run: npm run lint
       - run: npm run format:check
+      - run: npm run check:claims
       - run: npm run build
       - run: npm run check:links

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,6 +23,22 @@ jobs:
           node-version: '20'
           cache: 'npm'
       - run: npm ci
+      - run: npm run check:claims
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@ba7bc0a3fef59531c69a25acd34668d6d3fe6f22 # v4.1.0
+      - name: Sign machine-readable claims
+        run: |
+          cosign sign-blob \
+            --yes \
+            --bundle public/.well-known/claims.sigstore.json \
+            public/.well-known/claims.json
+      - name: Verify machine-readable claims
+        run: |
+          cosign verify-blob \
+            --bundle public/.well-known/claims.sigstore.json \
+            --certificate-identity https://github.com/bshastry/bshastry.github.io/.github/workflows/deploy.yml@refs/heads/master \
+            --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+            public/.well-known/claims.json
       - run: npm run build
       - uses: actions/configure-pages@v4
       - uses: actions/upload-pages-artifact@v3

--- a/.gitignore
+++ b/.gitignore
@@ -81,6 +81,7 @@ legacy-archive/
 # (a bare `scripts/` would make the file impossible to re-include).
 scripts/*
 !scripts/check-links.mjs
+!scripts/check-claims.mjs
 
 # Local research / drafts not intended for publication
 private/

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Personal portfolio and security-research blog for Bhargava Shastry, security eng
 - **Markdown pipeline:** `js-yaml` front matter + `remark` + `remark-gfm` + `remark-rehype` + `rehype-slug` + `rehype-autolink-headings` + `rehype-pretty-code` (Shiki) + `rehype-stringify`
 - **Icons:** `lucide-react`
 - **Hosting:** GitHub Pages via GitHub Actions
+- **Machine-readable trust:** Evidence-linked JSON claims with a deployment-generated Sigstore bundle
 - **Quality gates:** Prettier, ESLint (`next/core-web-vitals`), `tsc --noEmit`, all enforced in CI
 
 ## Local development
@@ -33,7 +34,8 @@ Open [http://localhost:3000](http://localhost:3000). The dev server hot-reloads 
 | `npm run lint:fix`     | ESLint with `--fix`                                             |
 | `npm run format`       | Prettier write                                                  |
 | `npm run format:check` | Prettier check (used in CI)                                     |
-| `npm run check`        | typecheck + lint + format:check                                 |
+| `npm run check`        | typecheck + lint + format:check + claims validation             |
+| `npm run check:claims` | Validate the claims contract, evidence shape, and freshness     |
 | `npm run check:links`  | Internal-link audit over `out/` (run after `build`; used in CI) |
 
 ## Writing a blog post
@@ -86,6 +88,7 @@ content/posts/            Blog markdown files
 
 docs/
   distribution-playbook.md  Channel selection, profile copy, and measurement cadence
+  verifiable-claims.md      Claims trust model, verification, and maintenance
 
 lib/
   blog.ts                 Markdown parsing pipeline
@@ -98,10 +101,13 @@ data/
 
 public/
   llms.txt                Curated agent-readable site index
+  .well-known/claims.json  Evidence-linked professional claims
+  .well-known/claims.schema.json  JSON Schema for the claims document
   .well-known/security.txt  RFC 9116 vulnerability-report contact (has an Expires date — renew yearly)
   <year>/.../*.html       Legacy Jekyll article redirects
 
 scripts/
+  check-claims.mjs        CI gate: validates claims structure, evidence, and expiry
   check-links.mjs         CI gate: fails the build on broken internal links in out/
 ```
 
@@ -109,8 +115,13 @@ scripts/
 
 Hosted at [bshastry.github.io](https://bshastry.github.io). Deployment is automated via GitHub Actions:
 
-- **`.github/workflows/ci.yml`** runs on every push and PR to any branch. It runs `npm run check`, `npm run build`, and `npm run check:links` to catch regressions before merge.
-- **`.github/workflows/deploy.yml`** runs only on push to `master`. It builds the static site and publishes `out/` to GitHub Pages.
+- **`.github/workflows/ci.yml`** runs on every push and PR to any branch. It
+  checks types, lint, formatting, claims, the production build, and internal
+  links to catch regressions before merge.
+- **`.github/workflows/deploy.yml`** runs only on push to `master`. It signs
+  `claims.json` with the workflow's keyless GitHub Actions identity, verifies
+  the Sigstore bundle, builds the static site, and publishes `out/` to GitHub
+  Pages.
 
 ### Repo-level settings (one-time)
 
@@ -123,6 +134,9 @@ No custom domain is configured; the site serves from the default `bshastry.githu
 - **Dependencies:** Update periodically with `npm outdated` + `npm update`. For major bumps (Next.js, Tailwind), test thoroughly in a branch first.
 - **Legacy continuity:** Keep the static redirect files under `public/` and the `/bugs/` alias when changing routes; external links to the Jekyll-era site still depend on them.
 - **Content updates:** Blog posts live in `content/posts/`; portfolio data (projects, CV) lives in `data/portfolio.json`.
+- **Claims:** Review `public/.well-known/claims.json` at least yearly, update its
+  dates and evidence with any substantive change, and follow
+  [`docs/verifiable-claims.md`](docs/verifiable-claims.md).
 - **Distribution:** Use [`docs/distribution-playbook.md`](docs/distribution-playbook.md) for
   channel selection, profile alignment, community rules, and the six-week review cadence.
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -75,6 +75,13 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
       suppressHydrationWarning
     >
       <head>
+        <link
+          rel="alternate"
+          type="application/json"
+          href="/.well-known/claims.json"
+          title="Verifiable professional claims"
+        />
+        <link rel="alternate" type="text/plain" href="/llms.txt" title="LLM site index" />
         <script dangerouslySetInnerHTML={{ __html: themeScript }} />
       </head>
       <body className={inter.className}>

--- a/docs/verifiable-claims.md
+++ b/docs/verifiable-claims.md
@@ -1,0 +1,59 @@
+# Verifiable machine-readable claims
+
+The site publishes an evidence-linked professional claims document at
+[`/.well-known/claims.json`](https://bshastry.github.io/.well-known/claims.json).
+It is intended for first-pass candidate and vendor screening, agent discovery,
+and evidence verification.
+
+## Files
+
+- `claims.json` is the versioned claims document.
+- `claims.schema.json` is its JSON Schema contract.
+- `claims.sigstore.json` is a Sigstore bundle generated during each production
+  deployment. It is deliberately not stored in the repository because every
+  deployment signs the exact bytes it publishes.
+
+The claim document separates the statement, typed value, status, evidence, and
+assurance basis. A signature proves which workflow published those bytes; it
+does not make the underlying statement independently true. Consumers should
+follow the evidence and apply their own freshness and trust policy.
+
+## Verify a deployed claim set
+
+Install
+[Cosign](https://docs.sigstore.dev/cosign/system_config/installation/), download
+the deployed document and bundle without modifying them, then run:
+
+```bash
+curl -fsSLO https://bshastry.github.io/.well-known/claims.json
+curl -fsSLO https://bshastry.github.io/.well-known/claims.sigstore.json
+cosign verify-blob \
+  --bundle claims.sigstore.json \
+  --certificate-identity https://github.com/bshastry/bshastry.github.io/.github/workflows/deploy.yml@refs/heads/master \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  claims.json
+```
+
+Successful verification establishes that:
+
+1. `claims.json` has not changed since signing.
+2. The signing certificate was issued to this repository's `deploy.yml`
+   workflow running from `refs/heads/master`.
+3. The bundle contains the verification material and transparency-log proof
+   expected by Cosign.
+
+## Maintain claims
+
+When changing a claim:
+
+1. Keep the statement narrow enough for every cited source to support it.
+2. Label first-party assertions as `self-asserted`; use `evidence-linked` only
+   when the claim includes evidence beyond the assertion itself.
+3. Update `reviewedAt`, `issuedAt`, and `validUntil`.
+4. Run `npm run check:claims`.
+5. If the structure changes, version the schema and update the document's
+   `$schema` reference.
+
+Production deploys validate the document, use keyless GitHub Actions OIDC to
+sign it, verify the resulting bundle against the expected workflow identity,
+and only then build the static site.

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "typecheck": "tsc --noEmit",
-    "check": "npm run typecheck && npm run lint && npm run format:check",
+    "check": "npm run typecheck && npm run lint && npm run format:check && npm run check:claims",
+    "check:claims": "node scripts/check-claims.mjs",
     "check:links": "node scripts/check-links.mjs"
   },
   "dependencies": {

--- a/public/.well-known/claims.json
+++ b/public/.well-known/claims.json
@@ -1,0 +1,282 @@
+{
+  "$schema": "https://bshastry.github.io/.well-known/claims.schema.json",
+  "id": "https://bshastry.github.io/.well-known/claims.json",
+  "version": "1.0.0",
+  "issuedAt": "2026-07-26T00:00:00Z",
+  "validUntil": "2027-07-26T00:00:00Z",
+  "purpose": [
+    "candidate-screening",
+    "vendor-screening",
+    "agent-discovery",
+    "evidence-verification"
+  ],
+  "issuer": {
+    "id": "https://bshastry.github.io/#bhargava-shastry",
+    "type": "Person",
+    "name": "Bhargava Shastry"
+  },
+  "subject": {
+    "id": "https://bshastry.github.io/#bhargava-shastry",
+    "type": "Person",
+    "name": "Bhargava Shastry"
+  },
+  "profiles": [
+    {
+      "service": "GitHub",
+      "url": "https://github.com/bshastry"
+    },
+    {
+      "service": "Google Scholar",
+      "url": "https://scholar.google.com/citations?hl=en&user=lsdZxf8AAAAJ"
+    },
+    {
+      "service": "Keybase",
+      "url": "https://keybase.io/bshastry"
+    }
+  ],
+  "claims": [
+    {
+      "id": "https://bshastry.github.io/.well-known/claims.json#identity-name",
+      "type": "IdentityClaim",
+      "statement": "The subject publishes professionally as Bhargava Shastry.",
+      "predicate": "https://schema.org/name",
+      "object": {
+        "type": "Text",
+        "value": "Bhargava Shastry"
+      },
+      "status": "active",
+      "evidence": [
+        {
+          "url": "https://bshastry.github.io/",
+          "title": "Official portfolio",
+          "sourceType": "issuer"
+        },
+        {
+          "url": "https://github.com/bshastry",
+          "title": "GitHub profile",
+          "sourceType": "independent"
+        },
+        {
+          "url": "https://keybase.io/bshastry",
+          "title": "Keybase identity",
+          "sourceType": "independent"
+        }
+      ],
+      "assurance": {
+        "level": "evidence-linked",
+        "basis": ["first-party-assertion", "independent-source"],
+        "reviewedAt": "2026-07-26"
+      }
+    },
+    {
+      "id": "https://bshastry.github.io/.well-known/claims.json#professional-role",
+      "type": "ProfessionalClaim",
+      "statement": "Bhargava Shastry is a security engineer and researcher focused on differential testing and protocol security.",
+      "predicate": "https://schema.org/jobTitle",
+      "object": {
+        "type": "Text",
+        "value": "Security Engineer and Researcher"
+      },
+      "status": "active",
+      "evidence": [
+        {
+          "url": "https://bshastry.github.io/",
+          "title": "Official portfolio",
+          "sourceType": "issuer"
+        },
+        {
+          "url": "https://bshastry.github.io/media/Bhargava_Shastry_CV.pdf",
+          "title": "Curriculum vitae",
+          "sourceType": "issuer"
+        }
+      ],
+      "assurance": {
+        "level": "self-asserted",
+        "basis": ["first-party-assertion"],
+        "reviewedAt": "2026-07-26"
+      }
+    },
+    {
+      "id": "https://bshastry.github.io/.well-known/claims.json#expertise-domains",
+      "type": "ExpertiseClaim",
+      "statement": "The subject's published work covers differential testing, Ethereum protocol security, compiler security, fuzzing, post-quantum cryptography, and side-channel analysis.",
+      "predicate": "https://schema.org/knowsAbout",
+      "object": {
+        "type": "TextList",
+        "value": [
+          "Differential testing",
+          "Ethereum protocol security",
+          "Compiler security",
+          "Fuzzing",
+          "Post-quantum cryptography",
+          "Side-channel analysis"
+        ]
+      },
+      "status": "active",
+      "evidence": [
+        {
+          "url": "https://bshastry.github.io/research/",
+          "title": "Research archive",
+          "sourceType": "issuer"
+        },
+        {
+          "url": "https://scholar.google.com/citations?hl=en&user=lsdZxf8AAAAJ",
+          "title": "Google Scholar profile",
+          "sourceType": "independent"
+        },
+        {
+          "url": "https://github.com/bshastry",
+          "title": "Public code and contribution history",
+          "sourceType": "independent"
+        }
+      ],
+      "assurance": {
+        "level": "evidence-linked",
+        "basis": ["first-party-assertion", "independent-source"],
+        "reviewedAt": "2026-07-26"
+      }
+    },
+    {
+      "id": "https://bshastry.github.io/.well-known/claims.json#published-cves",
+      "type": "TrackRecordClaim",
+      "statement": "The public findings ledger contains a historical archive of 55 published CVEs.",
+      "predicate": "https://schema.org/numberOfItems",
+      "object": {
+        "type": "Number",
+        "value": 55,
+        "unit": "published CVE records",
+        "qualifier": "Historical archive; verify individual records through the linked ledger and registry."
+      },
+      "status": "historical",
+      "evidence": [
+        {
+          "url": "https://bshastry.github.io/findings/#cve-ledger",
+          "title": "CVE disclosure ledger",
+          "sourceType": "issuer"
+        },
+        {
+          "url": "https://nvd.nist.gov/vuln/search",
+          "title": "National Vulnerability Database search",
+          "sourceType": "registry"
+        }
+      ],
+      "assurance": {
+        "level": "evidence-linked",
+        "basis": ["first-party-assertion", "derived-from-public-ledger"],
+        "reviewedAt": "2026-07-26"
+      }
+    },
+    {
+      "id": "https://bshastry.github.io/.well-known/claims.json#solidity-miscompilations",
+      "type": "TrackRecordClaim",
+      "statement": "SolSmith found 25 patched Solidity compiler miscompilation bugs; seven are cross-referenced in Solidity's official security-relevant bug ledger.",
+      "predicate": "https://schema.org/result",
+      "object": {
+        "type": "StructuredValue",
+        "value": {
+          "patchedMiscompilationBugs": 25,
+          "officialSecurityLedgerEntries": 7,
+          "tool": "SolSmith"
+        },
+        "qualifier": "Counts are tied to the cited paper and ledger cross-reference."
+      },
+      "status": "historical",
+      "evidence": [
+        {
+          "url": "https://arxiv.org/abs/2607.07217",
+          "title": "Finding and Understanding Miscompilation Bugs in the Solidity Compiler",
+          "sourceType": "primary"
+        },
+        {
+          "url": "https://bshastry.github.io/findings/#solidity-security-bugs",
+          "title": "SolSmith-to-Solidity bug-ledger cross-reference",
+          "sourceType": "issuer"
+        },
+        {
+          "url": "https://github.com/argotorg/solidity/blob/develop/docs/bugs_by_version.json",
+          "title": "Solidity security-relevant bug ledger",
+          "sourceType": "registry"
+        }
+      ],
+      "assurance": {
+        "level": "evidence-linked",
+        "basis": ["primary-source", "derived-from-public-ledger"],
+        "reviewedAt": "2026-07-26"
+      }
+    },
+    {
+      "id": "https://bshastry.github.io/.well-known/claims.json#independent-services",
+      "type": "ServiceClaim",
+      "statement": "Independent security engagements are offered by enquiry, subject to an Ethereum Foundation conflict-of-interest check and a separate availability discussion.",
+      "predicate": "https://schema.org/makesOffer",
+      "object": {
+        "type": "TextList",
+        "value": [
+          "Differential-testing diagnostic",
+          "Critical implementation review",
+          "Constant-time analysis",
+          "Technical workshop"
+        ],
+        "qualifier": "An enquiry is not an availability commitment."
+      },
+      "status": "conditional",
+      "evidence": [
+        {
+          "url": "https://bshastry.github.io/engagements/",
+          "title": "Independent engagement scope and process",
+          "sourceType": "issuer"
+        }
+      ],
+      "assurance": {
+        "level": "self-asserted",
+        "basis": ["first-party-assertion"],
+        "reviewedAt": "2026-07-26"
+      }
+    },
+    {
+      "id": "https://bshastry.github.io/.well-known/claims.json#security-contact",
+      "type": "ContactClaim",
+      "statement": "Sensitive vulnerability reports should use the published encryption key rather than ordinary email.",
+      "predicate": "https://schema.org/contactPoint",
+      "object": {
+        "type": "StructuredValue",
+        "value": {
+          "securityPolicy": "https://bshastry.github.io/.well-known/security.txt",
+          "encryptionKey": "https://keybase.io/bshastry/pgp_keys.asc",
+          "email": "bshastry@posteo.de"
+        }
+      },
+      "status": "active",
+      "evidence": [
+        {
+          "url": "https://bshastry.github.io/.well-known/security.txt",
+          "title": "RFC 9116 security contact",
+          "sourceType": "issuer"
+        },
+        {
+          "url": "https://keybase.io/bshastry/pgp_keys.asc",
+          "title": "Published PGP key",
+          "sourceType": "independent"
+        }
+      ],
+      "assurance": {
+        "level": "evidence-linked",
+        "basis": ["first-party-assertion", "independent-source"],
+        "reviewedAt": "2026-07-26"
+      }
+    }
+  ],
+  "signature": {
+    "format": "sigstore-bundle",
+    "artifact": "https://bshastry.github.io/.well-known/claims.json",
+    "bundle": "https://bshastry.github.io/.well-known/claims.sigstore.json",
+    "certificateIdentity": "https://github.com/bshastry/bshastry.github.io/.github/workflows/deploy.yml@refs/heads/master",
+    "certificateOidcIssuer": "https://token.actions.githubusercontent.com",
+    "verificationCommand": "cosign verify-blob --bundle claims.sigstore.json --certificate-identity https://github.com/bshastry/bshastry.github.io/.github/workflows/deploy.yml@refs/heads/master --certificate-oidc-issuer https://token.actions.githubusercontent.com claims.json"
+  },
+  "disclaimer": [
+    "The Sigstore signature authenticates the deployed file and its GitHub Actions publishing identity; it does not independently prove every claim.",
+    "Screening agents should evaluate each claim's assurance level, follow its evidence, and apply their own freshness and trust policies.",
+    "References to the Ethereum Foundation describe professional context and conflict checks; they do not imply endorsement of independent services."
+  ]
+}

--- a/public/.well-known/claims.json
+++ b/public/.well-known/claims.json
@@ -150,7 +150,7 @@
       "status": "historical",
       "evidence": [
         {
-          "url": "https://bshastry.github.io/findings/#cve-ledger",
+          "url": "https://bshastry.github.io/findings/#cve-disclosures",
           "title": "CVE disclosure ledger",
           "sourceType": "issuer"
         },

--- a/public/.well-known/claims.schema.json
+++ b/public/.well-known/claims.schema.json
@@ -1,0 +1,331 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://bshastry.github.io/.well-known/claims.schema.json",
+  "title": "Bhargava Shastry verifiable claims",
+  "description": "A versioned, evidence-linked set of first-party professional claims with Sigstore verification metadata.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "$schema",
+    "id",
+    "version",
+    "issuedAt",
+    "validUntil",
+    "purpose",
+    "issuer",
+    "subject",
+    "profiles",
+    "claims",
+    "signature",
+    "disclaimer"
+  ],
+  "properties": {
+    "$schema": {
+      "const": "https://bshastry.github.io/.well-known/claims.schema.json"
+    },
+    "id": {
+      "const": "https://bshastry.github.io/.well-known/claims.json"
+    },
+    "version": {
+      "type": "string",
+      "pattern": "^[1-9][0-9]*\\.[0-9]+\\.[0-9]+$"
+    },
+    "issuedAt": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "validUntil": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "purpose": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {
+        "enum": [
+          "candidate-screening",
+          "vendor-screening",
+          "agent-discovery",
+          "evidence-verification"
+        ]
+      }
+    },
+    "issuer": {
+      "$ref": "#/$defs/entity"
+    },
+    "subject": {
+      "$ref": "#/$defs/entity"
+    },
+    "profiles": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/$defs/profile"
+      }
+    },
+    "claims": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/$defs/claim"
+      }
+    },
+    "signature": {
+      "$ref": "#/$defs/signature"
+    },
+    "disclaimer": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    }
+  },
+  "$defs": {
+    "httpsUri": {
+      "type": "string",
+      "format": "uri",
+      "pattern": "^https://"
+    },
+    "entity": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "type", "name"],
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/httpsUri"
+        },
+        "type": {
+          "const": "Person"
+        },
+        "name": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "profile": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["service", "url"],
+      "properties": {
+        "service": {
+          "type": "string",
+          "minLength": 1
+        },
+        "url": {
+          "$ref": "#/$defs/httpsUri"
+        }
+      }
+    },
+    "claimObject": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["type", "value"],
+      "properties": {
+        "type": {
+          "enum": ["Text", "Number", "Boolean", "TextList", "StructuredValue"]
+        },
+        "value": {},
+        "unit": {
+          "type": "string",
+          "minLength": 1
+        },
+        "qualifier": {
+          "type": "string",
+          "minLength": 1
+        }
+      },
+      "oneOf": [
+        {
+          "properties": {
+            "type": {
+              "const": "Text"
+            },
+            "value": {
+              "type": "string",
+              "minLength": 1
+            }
+          }
+        },
+        {
+          "properties": {
+            "type": {
+              "const": "Number"
+            },
+            "value": {
+              "type": "number"
+            }
+          }
+        },
+        {
+          "properties": {
+            "type": {
+              "const": "Boolean"
+            },
+            "value": {
+              "type": "boolean"
+            }
+          }
+        },
+        {
+          "properties": {
+            "type": {
+              "const": "TextList"
+            },
+            "value": {
+              "type": "array",
+              "minItems": 1,
+              "uniqueItems": true,
+              "items": {
+                "type": "string",
+                "minLength": 1
+              }
+            }
+          }
+        },
+        {
+          "properties": {
+            "type": {
+              "const": "StructuredValue"
+            },
+            "value": {
+              "type": "object"
+            }
+          }
+        }
+      ]
+    },
+    "evidence": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["url", "title", "sourceType"],
+      "properties": {
+        "url": {
+          "$ref": "#/$defs/httpsUri"
+        },
+        "title": {
+          "type": "string",
+          "minLength": 1
+        },
+        "sourceType": {
+          "enum": ["issuer", "primary", "independent", "registry"]
+        }
+      }
+    },
+    "assurance": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["level", "basis", "reviewedAt"],
+      "properties": {
+        "level": {
+          "enum": ["self-asserted", "evidence-linked"]
+        },
+        "basis": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "enum": [
+              "first-party-assertion",
+              "primary-source",
+              "independent-source",
+              "derived-from-public-ledger"
+            ]
+          }
+        },
+        "reviewedAt": {
+          "type": "string",
+          "format": "date"
+        }
+      }
+    },
+    "claim": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "type",
+        "statement",
+        "predicate",
+        "object",
+        "status",
+        "evidence",
+        "assurance"
+      ],
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/httpsUri"
+        },
+        "type": {
+          "enum": [
+            "IdentityClaim",
+            "ProfessionalClaim",
+            "ExpertiseClaim",
+            "TrackRecordClaim",
+            "ServiceClaim",
+            "ContactClaim"
+          ]
+        },
+        "statement": {
+          "type": "string",
+          "minLength": 1
+        },
+        "predicate": {
+          "$ref": "#/$defs/httpsUri"
+        },
+        "object": {
+          "$ref": "#/$defs/claimObject"
+        },
+        "status": {
+          "enum": ["active", "historical", "conditional"]
+        },
+        "evidence": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/$defs/evidence"
+          }
+        },
+        "assurance": {
+          "$ref": "#/$defs/assurance"
+        }
+      }
+    },
+    "signature": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "format",
+        "artifact",
+        "bundle",
+        "certificateIdentity",
+        "certificateOidcIssuer",
+        "verificationCommand"
+      ],
+      "properties": {
+        "format": {
+          "const": "sigstore-bundle"
+        },
+        "artifact": {
+          "const": "https://bshastry.github.io/.well-known/claims.json"
+        },
+        "bundle": {
+          "const": "https://bshastry.github.io/.well-known/claims.sigstore.json"
+        },
+        "certificateIdentity": {
+          "const": "https://github.com/bshastry/bshastry.github.io/.github/workflows/deploy.yml@refs/heads/master"
+        },
+        "certificateOidcIssuer": {
+          "const": "https://token.actions.githubusercontent.com"
+        },
+        "verificationCommand": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    }
+  }
+}

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -13,6 +13,9 @@ Do not send vulnerability details, credentials, secrets, or source code by ordin
 ## Primary
 
 - [Portfolio](https://bshastry.github.io/): Current work, case studies, selected findings, talks, publications, and engagement information.
+- [Verifiable claims](https://bshastry.github.io/.well-known/claims.json): Signed, structured professional claims for candidate screening, vendor screening, and evidence verification.
+- [Claims schema](https://bshastry.github.io/.well-known/claims.schema.json): JSON Schema contract for the claims document.
+- [Sigstore bundle](https://bshastry.github.io/.well-known/claims.sigstore.json): Deployment-generated signature, certificate, and transparency-log proof for the exact claims document bytes.
 - [Security findings and disclosures](https://bshastry.github.io/findings/): Complete CVE-backed disclosure ledger plus the cross-reference between SolSmith findings and Solidity's official security-relevant compiler-bug records.
 - [Research archive](https://bshastry.github.io/research/): Current and historical research themes, tools, and upstream work.
 - [Curriculum vitae](https://bshastry.github.io/media/Bhargava_Shastry_CV.pdf): Current PDF CV.
@@ -20,6 +23,8 @@ Do not send vulnerability details, credentials, secrets, or source code by ordin
 - [RSS feed](https://bshastry.github.io/feed.xml): Machine-readable blog feed.
 - [Email](mailto:bshastry@posteo.de): Initial enquiries only; do not include sensitive material.
 - [PGP key](https://keybase.io/bshastry/pgp_keys.asc): Encryption key for sensitive reports.
+
+Agents should treat the signature as proof of publication identity and integrity, not as independent proof of every statement. Each structured claim includes an assurance level and evidence links that should be evaluated under the consumer's own trust and freshness policy.
 
 ## Selected writing
 

--- a/scripts/check-claims.mjs
+++ b/scripts/check-claims.mjs
@@ -1,0 +1,235 @@
+import { readFile } from 'node:fs/promises'
+import { URL, fileURLToPath } from 'node:url'
+import path from 'node:path'
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
+const claimsPath = path.join(root, 'public', '.well-known', 'claims.json')
+const schemaPath = path.join(root, 'public', '.well-known', 'claims.schema.json')
+
+function assert(condition, message) {
+  if (!condition) throw new Error(message)
+}
+
+function assertExactKeys(value, expected, label) {
+  const actual = Object.keys(value).sort()
+  const wanted = [...expected].sort()
+  assert(
+    JSON.stringify(actual) === JSON.stringify(wanted),
+    `${label} has unexpected keys: ${actual.join(', ')}`,
+  )
+}
+
+function assertHttps(value, label) {
+  const url = new URL(value)
+  assert(url.protocol === 'https:', `${label} must use https`)
+}
+
+function assertDate(value, label, dateOnly = false) {
+  const pattern = dateOnly ? /^\d{4}-\d{2}-\d{2}$/ : /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/
+  assert(pattern.test(value), `${label} is not a supported ISO date`)
+  assert(!Number.isNaN(Date.parse(value)), `${label} is not a valid date`)
+}
+
+const [claimsRaw, schemaRaw] = await Promise.all([
+  readFile(claimsPath, 'utf8'),
+  readFile(schemaPath, 'utf8'),
+])
+const claims = JSON.parse(claimsRaw)
+const schema = JSON.parse(schemaRaw)
+
+assert(claimsRaw.endsWith('\n'), 'claims.json must end with a newline')
+assert(schemaRaw.endsWith('\n'), 'claims.schema.json must end with a newline')
+
+assertExactKeys(
+  claims,
+  [
+    '$schema',
+    'id',
+    'version',
+    'issuedAt',
+    'validUntil',
+    'purpose',
+    'issuer',
+    'subject',
+    'profiles',
+    'claims',
+    'signature',
+    'disclaimer',
+  ],
+  'claims document',
+)
+assert(claims.$schema === schema.$id, 'claims.$schema must match schema.$id')
+assert(claims.id === claims.signature.artifact, 'signature artifact must match claims.id')
+assert(/^[1-9]\d*\.\d+\.\d+$/.test(claims.version), 'version must be semantic')
+assertDate(claims.issuedAt, 'issuedAt')
+assertDate(claims.validUntil, 'validUntil')
+assert(
+  Date.parse(claims.validUntil) > Date.parse(claims.issuedAt),
+  'validUntil must be later than issuedAt',
+)
+assert(Date.parse(claims.validUntil) > Date.now(), 'claims document has expired')
+assert(Array.isArray(claims.purpose) && claims.purpose.length > 0, 'purpose is required')
+assert(new Set(claims.purpose).size === claims.purpose.length, 'purpose values must be unique')
+
+for (const [label, entity] of [
+  ['issuer', claims.issuer],
+  ['subject', claims.subject],
+]) {
+  assertExactKeys(entity, ['id', 'type', 'name'], label)
+  assertHttps(entity.id, `${label}.id`)
+  assert(entity.type === 'Person', `${label}.type must be Person`)
+  assert(entity.name.length > 0, `${label}.name is required`)
+}
+assert(claims.issuer.id === claims.subject.id, 'issuer and subject must identify the same person')
+
+assert(Array.isArray(claims.profiles) && claims.profiles.length > 0, 'profiles are required')
+for (const [index, profile] of claims.profiles.entries()) {
+  assertExactKeys(profile, ['service', 'url'], `profiles[${index}]`)
+  assert(profile.service.length > 0, `profiles[${index}].service is required`)
+  assertHttps(profile.url, `profiles[${index}].url`)
+}
+
+assert(Array.isArray(claims.claims) && claims.claims.length > 0, 'claims are required')
+const claimIds = new Set()
+for (const [index, claim] of claims.claims.entries()) {
+  const label = `claims[${index}]`
+  assertExactKeys(
+    claim,
+    ['id', 'type', 'statement', 'predicate', 'object', 'status', 'evidence', 'assurance'],
+    label,
+  )
+  assertHttps(claim.id, `${label}.id`)
+  assert(claim.id.startsWith(`${claims.id}#`), `${label}.id must be anchored to claims.id`)
+  assert(!claimIds.has(claim.id), `${label}.id is duplicated`)
+  claimIds.add(claim.id)
+  assert(claim.statement.length > 0, `${label}.statement is required`)
+  assertHttps(claim.predicate, `${label}.predicate`)
+  assert(
+    [
+      'IdentityClaim',
+      'ProfessionalClaim',
+      'ExpertiseClaim',
+      'TrackRecordClaim',
+      'ServiceClaim',
+      'ContactClaim',
+    ].includes(claim.type),
+    `${label}.type is unsupported`,
+  )
+  const objectKeys = Object.keys(claim.object)
+  assert(
+    objectKeys.every((key) => ['type', 'value', 'unit', 'qualifier'].includes(key)),
+    `${label}.object has unexpected keys`,
+  )
+  assert(
+    ['Text', 'Number', 'Boolean', 'TextList', 'StructuredValue'].includes(claim.object.type),
+    `${label}.object.type is unsupported`,
+  )
+  assert(Object.hasOwn(claim.object, 'value'), `${label}.object.value is required`)
+  const valueIsValid = {
+    Text: () => typeof claim.object.value === 'string' && claim.object.value.length > 0,
+    Number: () => typeof claim.object.value === 'number' && Number.isFinite(claim.object.value),
+    Boolean: () => typeof claim.object.value === 'boolean',
+    TextList: () =>
+      Array.isArray(claim.object.value) &&
+      claim.object.value.length > 0 &&
+      claim.object.value.every((value) => typeof value === 'string' && value.length > 0) &&
+      new Set(claim.object.value).size === claim.object.value.length,
+    StructuredValue: () =>
+      claim.object.value !== null &&
+      typeof claim.object.value === 'object' &&
+      !Array.isArray(claim.object.value),
+  }
+  assert(valueIsValid[claim.object.type](), `${label}.object.value does not match its type`)
+  assert(
+    ['active', 'historical', 'conditional'].includes(claim.status),
+    `${label}.status is unsupported`,
+  )
+  assert(Array.isArray(claim.evidence) && claim.evidence.length > 0, `${label} needs evidence`)
+
+  const evidenceUrls = new Set()
+  for (const [evidenceIndex, evidence] of claim.evidence.entries()) {
+    const evidenceLabel = `${label}.evidence[${evidenceIndex}]`
+    assertExactKeys(evidence, ['url', 'title', 'sourceType'], evidenceLabel)
+    assertHttps(evidence.url, `${evidenceLabel}.url`)
+    assert(evidence.title.length > 0, `${evidenceLabel}.title is required`)
+    assert(
+      ['issuer', 'primary', 'independent', 'registry'].includes(evidence.sourceType),
+      `${evidenceLabel}.sourceType is unsupported`,
+    )
+    assert(!evidenceUrls.has(evidence.url), `${evidenceLabel}.url is duplicated`)
+    evidenceUrls.add(evidence.url)
+  }
+
+  assert(
+    ['self-asserted', 'evidence-linked'].includes(claim.assurance.level),
+    `${label}.assurance.level is unsupported`,
+  )
+  assert(
+    Array.isArray(claim.assurance.basis) && claim.assurance.basis.length > 0,
+    `${label}.assurance.basis is required`,
+  )
+  assert(
+    claim.assurance.basis.every((basis) =>
+      [
+        'first-party-assertion',
+        'primary-source',
+        'independent-source',
+        'derived-from-public-ledger',
+      ].includes(basis),
+    ),
+    `${label}.assurance.basis contains an unsupported value`,
+  )
+  assert(
+    new Set(claim.assurance.basis).size === claim.assurance.basis.length,
+    `${label}.assurance.basis values must be unique`,
+  )
+  assertDate(claim.assurance.reviewedAt, `${label}.assurance.reviewedAt`, true)
+  assert(
+    Date.parse(claim.assurance.reviewedAt) <= Date.parse(claim.issuedAt ?? claims.issuedAt),
+    `${label}.assurance.reviewedAt cannot be later than issuedAt`,
+  )
+}
+
+assertExactKeys(
+  claims.signature,
+  [
+    'format',
+    'artifact',
+    'bundle',
+    'certificateIdentity',
+    'certificateOidcIssuer',
+    'verificationCommand',
+  ],
+  'signature',
+)
+assert(claims.signature.format === 'sigstore-bundle', 'signature format must be sigstore-bundle')
+for (const field of ['artifact', 'bundle', 'certificateIdentity', 'certificateOidcIssuer']) {
+  assertHttps(claims.signature[field], `signature.${field}`)
+}
+assert(
+  claims.signature.certificateOidcIssuer === 'https://token.actions.githubusercontent.com',
+  'signature issuer must be GitHub Actions',
+)
+assert(
+  claims.signature.certificateIdentity.endsWith('/.github/workflows/deploy.yml@refs/heads/master'),
+  'signature identity must be the master deploy workflow',
+)
+for (const value of [
+  'cosign verify-blob',
+  '--bundle claims.sigstore.json',
+  `--certificate-identity ${claims.signature.certificateIdentity}`,
+  `--certificate-oidc-issuer ${claims.signature.certificateOidcIssuer}`,
+  'claims.json',
+]) {
+  assert(
+    claims.signature.verificationCommand.includes(value),
+    `verificationCommand is missing ${value}`,
+  )
+}
+
+assert(
+  Array.isArray(claims.disclaimer) && claims.disclaimer.length > 0,
+  'at least one trust-boundary disclaimer is required',
+)
+
+console.log(`Validated ${claims.claims.length} claims and ${claims.profiles.length} profiles.`)


### PR DESCRIPTION
Publishes a signed, structured, machine-readable professional claims surface for candidate/vendor screening agents, per the reviewed implementation plan.

## What's included

- **`public/.well-known/claims.json`** — seven scoped claims (identity, role, expertise, two track-record metrics, conditional independent services, security contact), each with a stable HTTPS ID, typed value, status, classified evidence, assurance level, and review date.
- **`public/.well-known/claims.schema.json`** — strict Draft 2020-12 JSON Schema contract (`additionalProperties: false`).
- **`scripts/check-claims.mjs`** — dependency-free validator enforcing structure, HTTPS, uniqueness, date/expiry, typed-value agreement, and signing-configuration invariants; wired into `npm run check`, CI, and deploy.
- **Deploy signing** — `deploy.yml` signs the exact `claims.json` bytes with keyless Sigstore (GitHub Actions OIDC, pinned `cosign-installer`), verifies the bundle against the master deploy-workflow identity, and ships `claims.sigstore.json` in the Pages artifact without committing it.
- **Discovery & docs** — links from the HTML head and `llms.txt`, plus `docs/verifiable-claims.md` covering the trust model, verification command, and maintenance.

## Review notes

The plan, execution prompt, and patch were checked for coherence against the repository at base `cbf99cf` (the exact inspected base). Claim values were verified against repo data: 55 CVEs in `lib/disclosures.ts` and the seven-entry Solidity ledger cross-reference both match. One defect was found and fixed in a follow-up commit: the CVE-ledger evidence URL cited the non-existent anchor `findings/#cve-ledger`; the anchor rendered by `DisclosureLedger` is `#cve-disclosures`.

## Verification run locally

- `npm run check` (typecheck, lint, Prettier, claims validator — 7 claims, 3 profiles) ✅
- Workflow YAML parsing for `ci.yml` and `deploy.yml` ✅
- `npm run build` — static export includes `claims.json` and `claims.schema.json` ✅
- `npm run check:links` — 67 pages, 1,208 internal references, no broken links ✅
- `git diff --check` ✅

Sigstore signing/verification runs only in the master deploy workflow, so the live bundle at `/.well-known/claims.sigstore.json` can be confirmed after this merges and deploys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018mWHJ5AvLA2yeypzHSt2dD

---
_Generated by [Claude Code](https://claude.ai/code/session_018mWHJ5AvLA2yeypzHSt2dD)_