### PR TITLE
Harden machine-readable claims against repository bitrot

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -40,6 +40,7 @@ jobs:
             --certificate-oidc-issuer https://token.actions.githubusercontent.com \
             public/.well-known/claims.json
       - run: npm run build
+      - run: npm run check:links
       - uses: actions/configure-pages@v4
       - uses: actions/upload-pages-artifact@v3
         with:

--- a/README.md
+++ b/README.md
@@ -25,18 +25,19 @@ Open [http://localhost:3000](http://localhost:3000). The dev server hot-reloads 
 
 ## Scripts
 
-| Command                | Purpose                                                         |
-| ---------------------- | --------------------------------------------------------------- |
-| `npm run dev`          | Local dev server with HMR                                       |
-| `npm run build`        | Static export to `out/`                                         |
-| `npm run typecheck`    | `tsc --noEmit`                                                  |
-| `npm run lint`         | ESLint (`next/core-web-vitals`)                                 |
-| `npm run lint:fix`     | ESLint with `--fix`                                             |
-| `npm run format`       | Prettier write                                                  |
-| `npm run format:check` | Prettier check (used in CI)                                     |
-| `npm run check`        | typecheck + lint + format:check + claims validation             |
-| `npm run check:claims` | Validate the claims contract, evidence shape, and freshness     |
-| `npm run check:links`  | Internal-link audit over `out/` (run after `build`; used in CI) |
+| Command                      | Purpose                                                         |
+| ---------------------------- | --------------------------------------------------------------- |
+| `npm run dev`                | Local dev server with HMR                                       |
+| `npm run build`              | Static export to `out/`                                         |
+| `npm run typecheck`          | `tsc --noEmit`                                                  |
+| `npm run lint`               | ESLint (`next/core-web-vitals`)                                 |
+| `npm run lint:fix`           | ESLint with `--fix`                                             |
+| `npm run format`             | Prettier write                                                  |
+| `npm run format:check`       | Prettier check (used in CI)                                     |
+| `npm run check`              | typecheck + lint + format:check + claims validation             |
+| `npm run check:claims`       | Validate the claims contract, evidence shape, and freshness     |
+| `npm run check:claims:links` | Audit built same-origin claims/llms links and anchors           |
+| `npm run check:links`        | Internal-link audit over `out/` (run after `build`; used in CI) |
 
 ## Writing a blog post
 
@@ -107,7 +108,7 @@ public/
   <year>/.../*.html       Legacy Jekyll article redirects
 
 scripts/
-  check-claims.mjs        CI gate: validates claims structure, evidence, and expiry
+  check-claims.mjs        CI gate: validates schema, source facts, links, and expiry
   check-links.mjs         CI gate: fails the build on broken internal links in out/
 ```
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -75,6 +75,7 @@ export default function Home() {
       />
       <Header />
       <main id="main-content" className="min-h-screen">
+        <span id="bhargava-shastry" aria-hidden="true" />
         <Hero latestPost={latestPost} publicationsCount={publicationsCount} />
         <CaseStudies />
         <About />

--- a/docs/verifiable-claims.md
+++ b/docs/verifiable-claims.md
@@ -54,6 +54,19 @@ When changing a claim:
 5. If the structure changes, version the schema and update the document's
    `$schema` reference.
 
+The claims check validates the document with the published JSON Schema and
+cross-checks the CVE and SolSmith counts against `lib/disclosures.ts`. After a
+static build, `npm run check:links` also resolves same-origin URLs from both the
+claims document and `llms.txt`, including HTML fragments, against `out/`. The
+Sigstore bundle is the one exception in ordinary CI because it is generated
+during deployment; the deploy workflow runs the same link check after creating
+the bundle.
+
+External evidence URLs are not fetched in blocking CI. Availability checks
+against third-party services are prone to rate limits, bot protection, and
+transient outages, so consumers must still evaluate those links under their own
+retrieval and freshness policy.
+
 Production deploys validate the document, use keyless GitHub Actions OIDC to
 sign it, verify the resulting bundle against the expected workflow identity,
 and only then build the static site.

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,8 @@
         "@types/node": "^20.0.0",
         "@types/react": "^18.0.0",
         "@types/react-dom": "^18.0.0",
+        "ajv": "^8.20.0",
+        "ajv-formats": "^3.0.1",
         "autoprefixer": "^10.0.0",
         "eslint": "^8.0.0",
         "eslint-config-next": "^15.5.19",
@@ -137,6 +139,30 @@
       "funding": {
         "url": "https://opencollective.com/eslint"
       }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/ajv": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@eslint/js": {
       "version": "8.57.1",
@@ -1776,20 +1802,38 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
-      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
-        "uri-js": "^4.2.2"
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
       }
     },
     "node_modules/ansi-regex": {
@@ -3308,6 +3352,30 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/eslint/node_modules/ajv": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/eslint/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/espree": {
       "version": "9.6.1",
       "resolved": "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz",
@@ -3428,6 +3496,23 @@
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/fastq": {
       "version": "1.20.1",
@@ -4623,9 +4708,9 @@
       "license": "MIT"
     },
     "node_modules/json-schema-traverse": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "dev": true,
       "license": "MIT"
     },
@@ -6784,6 +6869,16 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/resolve": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "typecheck": "tsc --noEmit",
     "check": "npm run typecheck && npm run lint && npm run format:check && npm run check:claims",
     "check:claims": "node scripts/check-claims.mjs",
-    "check:links": "node scripts/check-links.mjs"
+    "check:claims:links": "node scripts/check-claims.mjs --check-links",
+    "check:links": "node scripts/check-links.mjs && npm run check:claims:links"
   },
   "dependencies": {
     "js-yaml": "^4.2.0",
@@ -37,6 +38,8 @@
     "@types/node": "^20.0.0",
     "@types/react": "^18.0.0",
     "@types/react-dom": "^18.0.0",
+    "ajv": "^8.20.0",
+    "ajv-formats": "^3.0.1",
     "autoprefixer": "^10.0.0",
     "eslint": "^8.0.0",
     "eslint-config-next": "^15.5.19",

--- a/scripts/check-claims.mjs
+++ b/scripts/check-claims.mjs
@@ -1,10 +1,17 @@
-import { readFile } from 'node:fs/promises'
+import { readFile, stat } from 'node:fs/promises'
 import { URL, fileURLToPath } from 'node:url'
 import path from 'node:path'
+import Ajv2020 from 'ajv/dist/2020.js'
+import addFormats from 'ajv-formats'
+import ts from 'typescript'
 
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
 const claimsPath = path.join(root, 'public', '.well-known', 'claims.json')
 const schemaPath = path.join(root, 'public', '.well-known', 'claims.schema.json')
+const llmsPath = path.join(root, 'public', 'llms.txt')
+const disclosuresPath = path.join(root, 'lib', 'disclosures.ts')
+const outPath = path.join(root, 'out')
+const checkBuiltLinks = process.argv.includes('--check-links')
 
 function assert(condition, message) {
   if (!condition) throw new Error(message)
@@ -30,12 +37,175 @@ function assertDate(value, label, dateOnly = false) {
   assert(!Number.isNaN(Date.parse(value)), `${label} is not a valid date`)
 }
 
-const [claimsRaw, schemaRaw] = await Promise.all([
+function statementIncludesCount(statement, count) {
+  const smallNumberWords = [
+    'zero',
+    'one',
+    'two',
+    'three',
+    'four',
+    'five',
+    'six',
+    'seven',
+    'eight',
+    'nine',
+    'ten',
+    'eleven',
+    'twelve',
+    'thirteen',
+    'fourteen',
+    'fifteen',
+    'sixteen',
+    'seventeen',
+    'eighteen',
+    'nineteen',
+    'twenty',
+  ]
+  const tokens = [String(count)]
+  if (smallNumberWords[count]) tokens.push(smallNumberWords[count])
+  const normalized = statement.toLowerCase()
+  return tokens.some((token) => new RegExp(`\\b${token}\\b`).test(normalized))
+}
+
+async function loadDisclosureFacts() {
+  const source = await readFile(disclosuresPath, 'utf8')
+  const transpiled = ts.transpileModule(source, {
+    compilerOptions: {
+      module: ts.ModuleKind.ESNext,
+      target: ts.ScriptTarget.ES2020,
+    },
+    fileName: disclosuresPath,
+  }).outputText
+  const dataUrl = `data:text/javascript;base64,${Buffer.from(transpiled).toString('base64')}`
+  return import(dataUrl)
+}
+
+async function existingOutputPath(url) {
+  let pathname
+  try {
+    pathname = decodeURIComponent(url.pathname)
+  } catch {
+    throw new Error(`Malformed percent-encoding in ${url.href}`)
+  }
+
+  const relativePath = pathname.replace(/^\/+/, '')
+  const directPath = path.resolve(outPath, relativePath)
+  assert(
+    directPath === outPath || directPath.startsWith(`${outPath}${path.sep}`),
+    `${url.href} resolves outside out/`,
+  )
+  const candidates = pathname.endsWith('/')
+    ? [path.join(directPath, 'index.html')]
+    : [directPath, `${directPath}.html`, path.join(directPath, 'index.html')]
+
+  for (const candidate of candidates) {
+    try {
+      const metadata = await stat(candidate)
+      if (metadata.isFile()) return candidate
+    } catch (error) {
+      if (error.code !== 'ENOENT') throw error
+    }
+  }
+  return null
+}
+
+function collectHttpsUrls(value, label, collected) {
+  if (typeof value === 'string') {
+    if (!value.startsWith('https://')) return
+    collected.push({ label, url: new URL(value) })
+    return
+  }
+  if (Array.isArray(value)) {
+    value.forEach((item, index) => collectHttpsUrls(item, `${label}[${index}]`, collected))
+    return
+  }
+  if (value && typeof value === 'object') {
+    for (const [key, item] of Object.entries(value)) {
+      collectHttpsUrls(item, `${label}.${key}`, collected)
+    }
+  }
+}
+
+async function checkSameOriginLinks(claims, llmsRaw) {
+  const siteOrigin = new URL(claims.id).origin
+  const collected = []
+  collectHttpsUrls(claims, 'claims', collected)
+
+  for (const [index, match] of [
+    ...llmsRaw.matchAll(/\[[^\]]+\]\((https:\/\/[^)\s]+)\)/g),
+  ].entries()) {
+    collected.push({ label: `llms.txt link ${index + 1}`, url: new URL(match[1]) })
+  }
+
+  const unique = new Map()
+  for (const reference of collected) {
+    if (reference.url.origin !== siteOrigin) continue
+    unique.set(reference.url.href, reference)
+  }
+
+  const failures = []
+  let checked = 0
+  let deployGenerated = 0
+
+  for (const { label, url } of unique.values()) {
+    const outputFile = await existingOutputPath(url)
+    if (!outputFile && url.href === claims.signature.bundle) {
+      deployGenerated += 1
+      continue
+    }
+    checked += 1
+    if (!outputFile) {
+      failures.push(`${label}: ${url.href} does not resolve in out/`)
+      continue
+    }
+
+    if (!url.hash || !outputFile.endsWith('.html')) continue
+    let fragment
+    try {
+      fragment = decodeURIComponent(url.hash.slice(1))
+    } catch {
+      failures.push(`${label}: ${url.href} has malformed fragment encoding`)
+      continue
+    }
+    const html = await readFile(outputFile, 'utf8')
+    const ids = new Set(
+      [...html.matchAll(/\sid=(?:"([^"]+)"|'([^']+)')/g)].map((match) => match[1] ?? match[2]),
+    )
+    if (!ids.has(fragment)) {
+      failures.push(
+        `${label}: ${url.href} has no matching id in ${path.relative(root, outputFile)}`,
+      )
+    }
+  }
+
+  assert(
+    failures.length === 0,
+    `same-origin claim link validation failed:\n${failures.map((failure) => `  - ${failure}`).join('\n')}`,
+  )
+  console.log(
+    `Validated ${checked} same-origin claim/llms links and anchors` +
+      (deployGenerated > 0 ? `; deferred ${deployGenerated} deploy-generated bundle.` : '.'),
+  )
+}
+
+const [claimsRaw, schemaRaw, llmsRaw, disclosureFacts] = await Promise.all([
   readFile(claimsPath, 'utf8'),
   readFile(schemaPath, 'utf8'),
+  readFile(llmsPath, 'utf8'),
+  loadDisclosureFacts(),
 ])
 const claims = JSON.parse(claimsRaw)
 const schema = JSON.parse(schemaRaw)
+
+const ajv = new Ajv2020({ allErrors: true, strict: true })
+addFormats(ajv)
+const validateSchema = ajv.compile(schema)
+assert(
+  validateSchema(claims),
+  `claims.json does not satisfy claims.schema.json:\n${ajv.errorsText(validateSchema.errors, {
+    separator: '\n',
+  })}`,
+)
 
 assert(claimsRaw.endsWith('\n'), 'claims.json must end with a newline')
 assert(schemaRaw.endsWith('\n'), 'claims.schema.json must end with a newline')
@@ -232,4 +402,46 @@ assert(
   'at least one trust-boundary disclaimer is required',
 )
 
-console.log(`Validated ${claims.claims.length} claims and ${claims.profiles.length} profiles.`)
+const claimByFragment = new Map(
+  claims.claims.map((claim) => [new URL(claim.id).hash.slice(1), claim]),
+)
+const cveClaim = claimByFragment.get('published-cves')
+assert(cveClaim, 'published-cves claim is required')
+assert(
+  cveClaim.object.value === disclosureFacts.disclosureSummary.cves,
+  `published-cves value must match lib/disclosures.ts (${disclosureFacts.disclosureSummary.cves})`,
+)
+assert(
+  statementIncludesCount(cveClaim.statement, disclosureFacts.disclosureSummary.cves),
+  'published-cves statement must include the derived CVE count',
+)
+
+const solSmithClaim = claimByFragment.get('solidity-miscompilations')
+assert(solSmithClaim, 'solidity-miscompilations claim is required')
+assert(
+  solSmithClaim.object.value.patchedMiscompilationBugs ===
+    disclosureFacts.solSmithPatchedMiscompilations,
+  'SolSmith patched-miscompilation count must match lib/disclosures.ts',
+)
+assert(
+  solSmithClaim.object.value.officialSecurityLedgerEntries ===
+    disclosureFacts.soliditySecuritySummary.total,
+  'Solidity security-ledger count must match lib/disclosures.ts',
+)
+for (const count of [
+  disclosureFacts.solSmithPatchedMiscompilations,
+  disclosureFacts.soliditySecuritySummary.total,
+]) {
+  assert(
+    statementIncludesCount(solSmithClaim.statement, count),
+    `solidity-miscompilations statement must include the derived count ${count}`,
+  )
+}
+
+console.log(
+  `Validated ${claims.claims.length} claims and ${claims.profiles.length} profiles against schema and source facts.`,
+)
+
+if (checkBuiltLinks) {
+  await checkSameOriginLinks(claims, llmsRaw)
+}


### PR DESCRIPTION
Follow-up to #44: closes the bit-rot gaps in the signed claims surface that blocking CI previously could not see.

## What's included

- **Real JSON Schema validation** — `check:claims` now compiles `claims.schema.json` with Ajv (Draft 2020-12, strict mode, standard formats) and validates `claims.json` against it before the existing semantic checks, so document/schema divergence fails CI. Adds `ajv` and `ajv-formats` as devDependencies only.
- **Source-derived count cross-checks** — the CVE total and both SolSmith figures are now derived from `lib/disclosures.ts` (transpiled with the repo's existing TypeScript dependency) and compared against both the typed claim values and the human-readable statements. Editing the ledger without updating the claims now fails CI.
- **Same-origin route/anchor audit** — a new `--check-links` mode resolves every same-origin URL from `claims.json` and `llms.txt` against the built `out/`, including HTML fragment IDs. Wired into `check:links` so PR CI and the deploy workflow (after signing) both run it. The deploy-generated Sigstore bundle is deferred in ordinary CI and audited in the deploy job, where it exists.
- **Rot found and fixed by the new guard** — `issuer.id`/`subject.id` reference `/#bhargava-shastry`, but the homepage had no such anchor; a stable anchor span is added rather than exempting the URL.
- **Docs** — README script table and `docs/verifiable-claims.md` updated, including why external third-party URLs stay consumer-verified instead of being fetched in blocking CI.

## Review notes

The patch was validated against the current `master` (which contains #44, merged). Because #44 is merged, this lands as a new PR from the restarted branch rather than an update to #44. The `lib/disclosures.ts` loader was checked for safety: the file has no imports, so the data-URL module load is sound, and all three consumed exports (`disclosureSummary.cves`, `solSmithPatchedMiscompilations`, `soliditySecuritySummary.total`) are computed from the underlying arrays, not hardcoded.

## Verification run locally

- Clean `npm ci` — hand-edited lockfile is internally consistent ✅
- `npm run check` (typecheck, lint, Prettier, Ajv schema validation, semantic checks, source-fact cross-checks) ✅
- `npm run build` — 75 static pages ✅
- `npm run check:links` — 67 pages / 1,208 internal references, plus 26 same-origin claims/`llms.txt` targets with 1 deploy-generated bundle deferred ✅
- Workflow YAML parsing and `git diff --check` ✅
- Negative tests: mutating the CVE count fails with `published-cves value must match lib/disclosures.ts (55)`; renaming the homepage anchor fails the post-build audit ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018mWHJ5AvLA2yeypzHSt2dD

---
_Generated by [Claude Code](https://claude.ai/code/session_018mWHJ5AvLA2yeypzHSt2dD)_